### PR TITLE
Revamp Meserito login and employee UI

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import sys
+from pathlib import Path
 
 from PyQt6.QtWidgets import QApplication
 from sqlalchemy import select
@@ -67,6 +68,9 @@ def main() -> int:
     seed_database()
 
     app = QApplication(sys.argv)
+    stylesheet_path = Path(__file__).resolve().parent / "styles.qss"
+    if stylesheet_path.exists():
+        app.setStyleSheet(stylesheet_path.read_text(encoding="utf-8"))
     session = SessionLocal()
     auth_service = AuthService(session)
     window = LoginWindow(auth_service, SessionLocal)

--- a/app/styles.qss
+++ b/app/styles.qss
@@ -1,0 +1,201 @@
+* {
+    font-family: 'Poppins', 'Segoe UI', sans-serif;
+    color: #0d1b2a;
+}
+
+QWidget#backgroundWidget {
+    background: qlineargradient(
+        x1: 0, y1: 0, x2: 1, y2: 1,
+        stop: 0 #e3f2fd,
+        stop: 1 #bbdefb
+    );
+}
+
+QWidget#loginCard,
+QWidget#contentCard,
+QWidget#dialogCard {
+    background-color: #ffffff;
+    border-radius: 28px;
+}
+
+QWidget#dialogCard {
+    min-width: 360px;
+}
+
+QLabel#titleLabel {
+    color: #0d47a1;
+    font-size: 42px;
+    font-weight: 700;
+    letter-spacing: 1px;
+}
+
+QLabel#subtitleLabel {
+    color: #1976d2;
+    font-size: 18px;
+}
+
+QLabel#sectionTitle {
+    color: #0d47a1;
+    font-size: 20px;
+    font-weight: 600;
+}
+
+QLabel#sectionSubtitle {
+    color: #1e88e5;
+    font-size: 16px;
+}
+
+QLabel#promptLabel {
+    color: #0d47a1;
+    font-size: 16px;
+    font-weight: 600;
+}
+
+QLabel#sidebarHeader {
+    color: #1976d2;
+    font-size: 16px;
+    font-weight: 600;
+}
+
+QLabel#totalsLabel {
+    font-size: 16px;
+    color: #0d1b2a;
+}
+
+QLineEdit#userInput,
+QLineEdit#pinInput,
+QLineEdit#searchInput {
+    padding: 14px 16px;
+    border-radius: 16px;
+    border: 2px solid #d6e4ff;
+    background: #f7faff;
+    font-size: 16px;
+}
+
+QLineEdit#userInput:focus,
+QLineEdit#pinInput:focus,
+QLineEdit#searchInput:focus {
+    border: 2px solid #1e88e5;
+    background: #ffffff;
+}
+
+QSpinBox#quantitySpin {
+    min-height: 64px;
+    font-size: 28px;
+    border: 2px solid #d6e4ff;
+    border-radius: 18px;
+    background: #f7faff;
+    padding: 10px;
+}
+
+QSpinBox#quantitySpin:focus {
+    border: 2px solid #1e88e5;
+    background: #ffffff;
+}
+
+QPushButton#primaryButton,
+QPushButton#secondaryButton,
+QPushButton#menuItemButton {
+    padding: 16px 20px;
+    border-radius: 20px;
+    font-size: 16px;
+    font-weight: 600;
+    border: 2px solid transparent;
+}
+
+QPushButton#primaryButton {
+    background-color: #1565c0;
+    border-color: #1565c0;
+    color: #ffffff;
+}
+
+QPushButton#primaryButton:hover {
+    background-color: #ffffff;
+    color: #1565c0;
+}
+
+QPushButton#primaryButton:pressed {
+    background-color: #e3f2fd;
+    color: #0d47a1;
+}
+
+QPushButton#secondaryButton {
+    background-color: #ffffff;
+    color: #1565c0;
+    border-color: #1565c0;
+}
+
+QPushButton#secondaryButton:hover {
+    background-color: #1565c0;
+    color: #ffffff;
+}
+
+QPushButton#secondaryButton:pressed {
+    background-color: #bbdefb;
+    color: #0d47a1;
+}
+
+QPushButton#menuItemButton {
+    background-color: #f1f6ff;
+    color: #0d47a1;
+}
+
+QPushButton#menuItemButton:hover {
+    background-color: #ffffff;
+    color: #1565c0;
+    border-color: #1e88e5;
+}
+
+QPushButton#menuItemButton:pressed {
+    background-color: #bbdefb;
+    color: #0d47a1;
+}
+
+QListWidget#cartList {
+    border: none;
+    background: #f7faff;
+    border-radius: 20px;
+    padding: 12px;
+}
+
+QWidget#cartSidebar {
+    background: transparent;
+}
+
+QTabWidget#menuTabs::pane {
+    border: none;
+}
+
+QTabWidget#menuTabs QTabBar::tab {
+    background: #e3f2fd;
+    border-radius: 18px;
+    padding: 12px 24px;
+    margin: 6px;
+    color: #0d47a1;
+    font-weight: 600;
+}
+
+QTabWidget#menuTabs QTabBar::tab:selected {
+    background: #1565c0;
+    color: #ffffff;
+}
+
+QTabWidget#menuTabs QTabBar::tab:hover {
+    background: #bbdefb;
+}
+
+QScrollBar:vertical {
+    background: transparent;
+    width: 10px;
+    margin: 6px;
+}
+
+QScrollBar::handle:vertical {
+    background: #1e88e5;
+    border-radius: 5px;
+}
+
+QScrollBar::add-line:vertical,
+QScrollBar::sub-line:vertical {
+    height: 0;
+}

--- a/app/ui/components/cart_sidebar.py
+++ b/app/ui/components/cart_sidebar.py
@@ -9,15 +9,20 @@ class CartSidebar(QWidget):
     def __init__(self, parent=None) -> None:
         super().__init__(parent)
         self.setFixedWidth(260)
+        self.setObjectName("cartSidebar")
         self.order_id: int | None = None
         self.list_widget = QListWidget()
+        self.list_widget.setObjectName("cartList")
         self.totals_label = QLabel("Total: $0.00")
+        self.totals_label.setObjectName("totalsLabel")
         self.checkout_button = QPushButton("Cerrar cuenta")
+        self.checkout_button.setObjectName("primaryButton")
 
         layout = QVBoxLayout(self)
-        header = QLabel("Cuenta actual")
-        header.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        layout.addWidget(header)
+        self.header = QLabel("Cuenta actual")
+        self.header.setObjectName("sidebarHeader")
+        self.header.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(self.header)
         layout.addWidget(self.list_widget)
         layout.addWidget(self.totals_label)
         layout.addWidget(self.checkout_button)

--- a/app/ui/components/menu_browser.py
+++ b/app/ui/components/menu_browser.py
@@ -18,16 +18,19 @@ from ...models import Category, MenuItem
 class MenuBrowser(QWidget):
     def __init__(self, parent=None) -> None:
         super().__init__(parent)
+        self.setObjectName("menuBrowser")
         self._items_by_category: dict[int, list[MenuItem]] = {}
         self.on_item_selected: Callable[[MenuItem], None] | None = None
 
         layout = QVBoxLayout(self)
         self.search = QLineEdit()
         self.search.setPlaceholderText("Buscar...")
+        self.search.setObjectName("searchInput")
         self.search.textChanged.connect(self._filter_items)
         layout.addWidget(self.search)
 
         self.tabs = QTabWidget()
+        self.tabs.setObjectName("menuTabs")
         layout.addWidget(self.tabs)
 
     def set_menu(self, categories: Iterable[Category], items: Iterable[MenuItem]) -> None:
@@ -40,10 +43,12 @@ class MenuBrowser(QWidget):
         for category in categories:
             widget = QWidget()
             grid = QGridLayout(widget)
+            grid.setSpacing(16)
             row = col = 0
             for menu_item in self._items_by_category.get(category.id, []):
                 button = QPushButton(f"{menu_item.name}\n${menu_item.price_cents/100:.2f}")
-                button.setMinimumHeight(60)
+                button.setObjectName("menuItemButton")
+                button.setMinimumSize(160, 110)
                 button.clicked.connect(
                     lambda checked=False, item=menu_item: self._handle_item_clicked(item)
                 )

--- a/app/ui/windows/login_window.py
+++ b/app/ui/windows/login_window.py
@@ -45,10 +45,17 @@ class LoginWindow(QMainWindow):
         title.setObjectName("titleLabel")
         title.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
-        subtitle = QLabel("Bienvenido, ingrese su PIN para continuar")
+        subtitle = QLabel("Sistema de gestión para restaurantes")
         subtitle.setObjectName("subtitleLabel")
         subtitle.setAlignment(Qt.AlignmentFlag.AlignCenter)
         subtitle.setWordWrap(True)
+
+        user_label = QLabel("Código de empleado")
+        user_label.setObjectName("promptLabel")
+
+        self.user_edit = QLineEdit()
+        self.user_edit.setObjectName("userInput")
+        self.user_edit.setPlaceholderText("Ingrese su usuario")
 
         prompt_label = QLabel("Ingrese su PIN")
         prompt_label.setObjectName("promptLabel")
@@ -56,6 +63,7 @@ class LoginWindow(QMainWindow):
         self.pin_edit = QLineEdit()
         self.pin_edit.setObjectName("pinInput")
         self.pin_edit.setEchoMode(QLineEdit.EchoMode.Password)
+        self.pin_edit.setPlaceholderText("****")
 
         keypad_btn = QPushButton("Abrir teclado")
         keypad_btn.setObjectName("secondaryButton")
@@ -68,6 +76,8 @@ class LoginWindow(QMainWindow):
         card_layout.addWidget(title)
         card_layout.addWidget(subtitle)
         card_layout.addSpacing(10)
+        card_layout.addWidget(user_label)
+        card_layout.addWidget(self.user_edit)
         card_layout.addWidget(prompt_label)
         card_layout.addWidget(self.pin_edit)
         card_layout.addWidget(keypad_btn)
@@ -86,8 +96,6 @@ class LoginWindow(QMainWindow):
 
         self.setCentralWidget(background)
         self.setMinimumSize(640, 480)
-
-        self._apply_styles()
 
     def _open_keypad(self) -> None:
         dialog = KeypadDialog(parent=self)
@@ -112,82 +120,5 @@ class LoginWindow(QMainWindow):
         window.show()
         self._child_windows.append(window)
         self.pin_edit.clear()
+        self.user_edit.clear()
 
-    def _apply_styles(self) -> None:
-        self.setStyleSheet(
-            """
-            #backgroundWidget {
-                background: qlineargradient(
-                    x1: 0, y1: 0, x2: 1, y2: 1,
-                    stop: 0 #e3f2fd,
-                    stop: 1 #bbdefb
-                );
-                font-family: 'Segoe UI', 'Arial', sans-serif;
-            }
-
-            #loginCard {
-                background-color: #ffffff;
-                border-radius: 24px;
-            }
-
-            #titleLabel {
-                color: #0d47a1;
-                font-size: 36px;
-                font-weight: 700;
-                letter-spacing: 0.5px;
-            }
-
-            #subtitleLabel {
-                color: #1976d2;
-                font-size: 16px;
-            }
-
-            #promptLabel {
-                color: #0d47a1;
-                font-size: 15px;
-                font-weight: 600;
-            }
-
-            QLineEdit#pinInput {
-                padding: 14px 16px;
-                border-radius: 12px;
-                border: 2px solid #cfe2f3;
-                background: #f8fbff;
-                color: #0d47a1;
-                font-size: 18px;
-            }
-
-            QLineEdit#pinInput:focus {
-                border: 2px solid #1e88e5;
-                background: #ffffff;
-            }
-
-            QPushButton#primaryButton,
-            QPushButton#secondaryButton {
-                padding: 14px 18px;
-                border-radius: 14px;
-                font-size: 16px;
-                font-weight: 600;
-                border: 2px solid transparent;
-                background-color: #1e88e5;
-                color: #ffffff;
-            }
-
-            QPushButton#secondaryButton {
-                background-color: #1565c0;
-            }
-
-            QPushButton#primaryButton:hover,
-            QPushButton#secondaryButton:hover {
-                background-color: #ffffff;
-                color: #1e88e5;
-                border: 2px solid #1e88e5;
-            }
-
-            QPushButton#primaryButton:pressed,
-            QPushButton#secondaryButton:pressed {
-                background-color: #e3f2fd;
-                color: #0d47a1;
-            }
-            """
-        )

--- a/app/ui/windows/waiter_window.py
+++ b/app/ui/windows/waiter_window.py
@@ -1,9 +1,11 @@
-"""Main window for waiters."""
+"""Main window for waiters with a modern blue/white theme."""
 from __future__ import annotations
 
 from pathlib import Path
 from typing import Optional
 
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QColor
 from PyQt6.QtWidgets import (
     QDialog,
     QGridLayout,
@@ -13,41 +15,86 @@ from PyQt6.QtWidgets import (
     QMainWindow,
     QMessageBox,
     QPushButton,
+    QSpinBox,
     QVBoxLayout,
     QWidget,
+    QGraphicsDropShadowEffect,
 )
 
 from ...event_bus import event_bus
-from ...models import Table, Waiter
+from ...models import MenuItem, Table, Waiter
 from ...services import MenuService, OrderService, TableService, TicketService
 from ..components.cart_sidebar import CartSidebar
 from ..components.menu_browser import MenuBrowser
 from ..components.table_widget import TableWidget
 
 
-class MenuDialog(QDialog):
-    def __init__(self, menu_service: MenuService, order_service: OrderService, order_id: int, parent=None):
+class QuantityDialog(QDialog):
+    """Dialog to request the quantity of a selected product."""
+
+    def __init__(self, menu_item: MenuItem, parent: QWidget | None = None) -> None:
         super().__init__(parent)
-        self.setWindowTitle("Añadir pedido")
-        self.menu_service = menu_service
-        self.order_service = order_service
-        self.order_id = order_id
+        self.menu_item = menu_item
+        self.quantity = 1
+        self.setWindowTitle("Seleccionar cantidad")
+        self.setObjectName("quantityDialog")
+        self.setModal(True)
 
         layout = QVBoxLayout(self)
-        self.browser = MenuBrowser()
-        self.browser.on_item_selected = self._on_item
-        layout.addWidget(self.browser)
-        self._reload()
+        layout.setContentsMargins(0, 0, 0, 0)
 
-    def _reload(self) -> None:
-        categories = self.menu_service.list_categories(active_only=True)
-        items = []
-        for cat in categories:
-            items.extend(self.menu_service.list_items(category_id=cat.id))
-        self.browser.set_menu(categories, items)
+        card = QWidget()
+        card.setObjectName("dialogCard")
+        card_layout = QVBoxLayout(card)
+        card_layout.setContentsMargins(32, 32, 32, 32)
+        card_layout.setSpacing(16)
 
-    def _on_item(self, menu_item) -> None:
-        self.order_service.add_item(self.order_id, menu_item.id, qty=1)
+        title = QLabel(menu_item.name)
+        title.setObjectName("sectionTitle")
+        title.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+        price = QLabel(f"Precio: ${menu_item.price_cents / 100:.2f}")
+        price.setObjectName("sectionSubtitle")
+        price.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+        prompt = QLabel("¿Cuántas unidades desea agregar?")
+        prompt.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+        self.spin_box = QSpinBox()
+        self.spin_box.setObjectName("quantitySpin")
+        self.spin_box.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.spin_box.setRange(1, 99)
+        self.spin_box.setValue(1)
+
+        buttons = QHBoxLayout()
+        back_btn = QPushButton("Atrás")
+        back_btn.setObjectName("secondaryButton")
+        back_btn.clicked.connect(self.reject)
+
+        confirm_btn = QPushButton("Confirmar")
+        confirm_btn.setObjectName("primaryButton")
+        confirm_btn.clicked.connect(self._confirm)
+
+        buttons.addWidget(back_btn)
+        buttons.addWidget(confirm_btn)
+
+        card_layout.addWidget(title)
+        card_layout.addWidget(price)
+        card_layout.addSpacing(10)
+        card_layout.addWidget(prompt)
+        card_layout.addWidget(self.spin_box)
+        card_layout.addLayout(buttons)
+
+        shadow = QGraphicsDropShadowEffect(self)
+        shadow.setBlurRadius(32)
+        shadow.setOffset(0, 18)
+        shadow.setColor(QColor(30, 136, 229, 80))
+        card.setGraphicsEffect(shadow)
+
+        layout.addWidget(card)
+
+    def _confirm(self) -> None:
+        self.quantity = self.spin_box.value()
         self.accept()
 
 
@@ -65,32 +112,101 @@ class WaiterWindow(QMainWindow):
         event_bus.subscribe("order_updated", self._handle_order_event)
 
         central = QWidget()
-        layout = QHBoxLayout(central)
+        central.setObjectName("backgroundWidget")
+        main_layout = QVBoxLayout(central)
+        main_layout.setContentsMargins(48, 48, 48, 48)
+        main_layout.setSpacing(32)
+
+        title = QLabel("Meserito")
+        title.setObjectName("titleLabel")
+        title.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+        subtitle = QLabel("Panel de gestión para empleados")
+        subtitle.setObjectName("subtitleLabel")
+        subtitle.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+        cards_layout = QHBoxLayout()
+        cards_layout.setSpacing(24)
+
+        tables_card = QWidget()
+        tables_card.setObjectName("contentCard")
+        tables_layout = QVBoxLayout(tables_card)
+        tables_layout.setContentsMargins(32, 32, 32, 32)
+        tables_layout.setSpacing(20)
+
+        tables_title = QLabel("Mesas")
+        tables_title.setObjectName("sectionTitle")
+
+        self.info_label = QLabel("Seleccione una mesa para comenzar")
+        self.info_label.setObjectName("sectionSubtitle")
 
         self.table_container = QWidget()
         self.table_grid = QGridLayout(self.table_container)
-        layout.addWidget(self.table_container, 1)
-
-        right_panel = QVBoxLayout()
-        self.info_label = QLabel("Seleccione una mesa")
-        right_panel.addWidget(self.info_label)
+        self.table_grid.setSpacing(16)
 
         self.open_button = QPushButton("Abrir pedido")
+        self.open_button.setObjectName("primaryButton")
         self.open_button.clicked.connect(self._open_order)
-        right_panel.addWidget(self.open_button)
 
-        self.add_button = QPushButton("Añadir pedido")
-        self.add_button.clicked.connect(self._add_item)
-        right_panel.addWidget(self.add_button)
+        tables_layout.addWidget(tables_title)
+        tables_layout.addWidget(self.info_label)
+        tables_layout.addWidget(self.table_container)
+        tables_layout.addStretch(1)
+        tables_layout.addWidget(self.open_button)
+
+        menu_card = QWidget()
+        menu_card.setObjectName("contentCard")
+        menu_layout = QVBoxLayout(menu_card)
+        menu_layout.setContentsMargins(32, 32, 32, 32)
+        menu_layout.setSpacing(20)
+
+        menu_title = QLabel("Menú del restaurante")
+        menu_title.setObjectName("sectionTitle")
+
+        menu_hint = QLabel("Selecciona un producto para agregarlo al pedido")
+        menu_hint.setObjectName("sectionSubtitle")
+
+        self.menu_browser = MenuBrowser()
+        self.menu_browser.on_item_selected = self._handle_menu_item
+
+        menu_layout.addWidget(menu_title)
+        menu_layout.addWidget(menu_hint)
+        menu_layout.addWidget(self.menu_browser)
+
+        cart_card = QWidget()
+        cart_card.setObjectName("contentCard")
+        cart_layout = QVBoxLayout(cart_card)
+        cart_layout.setContentsMargins(32, 32, 32, 32)
+        cart_layout.setSpacing(20)
+
+        cart_title = QLabel("Resumen del pedido")
+        cart_title.setObjectName("sectionTitle")
 
         self.cart = CartSidebar()
         self.cart.checkout_button.clicked.connect(self._close_order)
-        right_panel.addWidget(self.cart)
+        if hasattr(self.cart, "header"):
+            self.cart.header.hide()
 
-        layout.addLayout(right_panel)
+        cart_layout.addWidget(cart_title)
+        cart_layout.addWidget(self.cart)
+        cart_layout.addStretch(1)
+
+        cards_layout.addWidget(tables_card, 1)
+        cards_layout.addWidget(menu_card, 2)
+        cards_layout.addWidget(cart_card, 1)
+
+        main_layout.addWidget(title)
+        main_layout.addWidget(subtitle)
+        main_layout.addLayout(cards_layout)
+
+        self._apply_shadow(tables_card)
+        self._apply_shadow(menu_card)
+        self._apply_shadow(cart_card)
 
         self.setCentralWidget(central)
+        self.setMinimumSize(1200, 720)
         self._load_tables()
+        self._load_menu()
 
     # Session helpers
     def _load_tables(self) -> None:
@@ -181,31 +297,6 @@ class WaiterWindow(QMainWindow):
             session.close()
         self._refresh_order()
 
-    def _add_item(self) -> None:
-        if not self.selected_table_id:
-            QMessageBox.warning(self, "Meserito", "Seleccione una mesa")
-            return
-        if not self.current_order_id:
-            QMessageBox.warning(self, "Meserito", "Primero abra un pedido")
-            return
-        session = self.session_factory()
-        try:
-            menu_service = MenuService(session)
-            order_service = OrderService(session)
-            dialog = MenuDialog(menu_service, order_service, self.current_order_id, self)
-            if dialog.exec():
-                order_service.compute_totals(self.current_order_id)
-                session.commit()
-                table_service = TableService(session)
-                table_service.mark_occupied(self.selected_table_id)
-                session.commit()
-        except Exception as exc:
-            session.rollback()
-            QMessageBox.critical(self, "Meserito", str(exc))
-        finally:
-            session.close()
-        self._refresh_order()
-
     def _close_order(self) -> None:
         if not self.current_order_id or not self.selected_table_id:
             QMessageBox.warning(self, "Meserito", "No hay pedido abierto")
@@ -242,3 +333,45 @@ class WaiterWindow(QMainWindow):
     def _handle_order_event(self, payload: dict) -> None:
         if payload.get("order_id") == self.current_order_id:
             self._refresh_order()
+
+    def _load_menu(self) -> None:
+        session = self.session_factory()
+        try:
+            menu_service = MenuService(session)
+            categories = menu_service.list_categories(active_only=True)
+            items = []
+            for cat in categories:
+                items.extend(menu_service.list_items(category_id=cat.id))
+        finally:
+            session.close()
+        self.menu_browser.set_menu(categories, items)
+
+    def _handle_menu_item(self, menu_item: MenuItem) -> None:
+        if not self.selected_table_id or not self.current_order_id:
+            QMessageBox.warning(self, "Meserito", "Seleccione una mesa y abra un pedido primero")
+            return
+        dialog = QuantityDialog(menu_item, self)
+        if not dialog.exec():
+            return
+        session = self.session_factory()
+        try:
+            order_service = OrderService(session)
+            table_service = TableService(session)
+            order_service.add_item(self.current_order_id, menu_item.id, qty=dialog.quantity)
+            order_service.compute_totals(self.current_order_id)
+            table_service.mark_occupied(self.selected_table_id)
+            session.commit()
+        except Exception as exc:
+            session.rollback()
+            QMessageBox.critical(self, "Meserito", str(exc))
+            return
+        finally:
+            session.close()
+        self._refresh_order()
+
+    def _apply_shadow(self, widget: QWidget) -> None:
+        shadow = QGraphicsDropShadowEffect(self)
+        shadow.setBlurRadius(36)
+        shadow.setOffset(0, 20)
+        shadow.setColor(QColor(30, 136, 229, 70))
+        widget.setGraphicsEffect(shadow)


### PR DESCRIPTION
## Summary
- add a shared QSS theme and load it from the application entry point to unify the blue and white branding
- refresh the login window with branded messaging, modern input styling, and aligned button treatments
- redesign the waiter window into card-style sections with the menu browser, quantity dialog, and cart sidebar styled for touch-friendly use

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'app')*


------
https://chatgpt.com/codex/tasks/task_e_68dc630b62ec8325a857bfdb11d9c94d