### PR TITLE
Add aggregated order summary tables for reporting

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1,10 +1,20 @@
 """SQLAlchemy models for Meserito."""
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
 from typing import List, Optional
 
-from sqlalchemy import CheckConstraint, Enum, ForeignKey, Integer, String, Text, func
+from sqlalchemy import (
+    CheckConstraint,
+    Date,
+    Enum,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    func,
+)
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from .db import Base
@@ -21,6 +31,9 @@ class Waiter(Base):
     created_at: Mapped[datetime] = mapped_column(default=func.now(), nullable=False)
 
     orders: Mapped[List["Order"]] = relationship(back_populates="waiter")
+    daily_sales: Mapped[List["OrdersByWaiter"]] = relationship(
+        back_populates="waiter", cascade="all, delete-orphan"
+    )
 
 
 class Table(Base):
@@ -44,6 +57,9 @@ class Table(Base):
     )
     orders: Mapped[List["Order"]] = relationship(
         "Order", back_populates="table", foreign_keys="Order.table_id"
+    )
+    daily_sales: Mapped[List["OrdersByTable"]] = relationship(
+        back_populates="table", cascade="all, delete-orphan"
     )
 
 
@@ -159,6 +175,54 @@ class AuditLog(Base):
     created_at: Mapped[datetime] = mapped_column(default=func.now(), nullable=False)
 
 
+class OrdersByDay(Base):
+    """Aggregated sales totals per calendar day."""
+
+    __tablename__ = "orders_by_day"
+
+    date: Mapped[date] = mapped_column(Date, primary_key=True)
+    total_orders: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    total_cents: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+
+    __table_args__ = (Index("ix_orders_by_day_date", "date"),)
+
+
+class OrdersByWaiter(Base):
+    """Aggregated sales totals per waiter and day."""
+
+    __tablename__ = "orders_by_waiter"
+
+    date: Mapped[date] = mapped_column(Date, primary_key=True)
+    waiter_id: Mapped[int] = mapped_column(ForeignKey("waiters.id"), primary_key=True)
+    total_orders: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    total_cents: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+
+    waiter: Mapped[Waiter] = relationship(back_populates="daily_sales")
+
+    __table_args__ = (
+        Index("ix_orders_by_waiter_date", "date"),
+        Index("ix_orders_by_waiter_waiter_id", "waiter_id"),
+    )
+
+
+class OrdersByTable(Base):
+    """Aggregated sales totals per table and day."""
+
+    __tablename__ = "orders_by_table"
+
+    date: Mapped[date] = mapped_column(Date, primary_key=True)
+    table_id: Mapped[int] = mapped_column(ForeignKey("tables.id"), primary_key=True)
+    total_orders: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    total_cents: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+
+    table: Mapped[Table] = relationship(back_populates="daily_sales")
+
+    __table_args__ = (
+        Index("ix_orders_by_table_date", "date"),
+        Index("ix_orders_by_table_table_id", "table_id"),
+    )
+
+
 __all__ = [
     "Waiter",
     "Table",
@@ -169,4 +233,7 @@ __all__ = [
     "Ticket",
     "Setting",
     "AuditLog",
+    "OrdersByDay",
+    "OrdersByWaiter",
+    "OrdersByTable",
 ]

--- a/app/services/report_service.py
+++ b/app/services/report_service.py
@@ -1,7 +1,30 @@
-"""Reporting utilities."""
+"""Reporting utilities.
+
+Example usage of the aggregated models::
+
+    session.execute(
+        select(OrdersByDay.date, OrdersByDay.total_cents)
+        .where(OrdersByDay.date.between(start, end))
+        .order_by(OrdersByDay.date)
+    )
+
+    session.execute(
+        select(Waiter.name, func.sum(OrdersByWaiter.total_cents))
+        .join(OrdersByWaiter, OrdersByWaiter.waiter_id == Waiter.id)
+        .where(OrdersByWaiter.date.between(start, end))
+        .group_by(Waiter.name)
+    )
+
+    session.execute(
+        select(Table.number, func.sum(OrdersByTable.total_cents))
+        .join(OrdersByTable, OrdersByTable.table_id == Table.id)
+        .where(OrdersByTable.date.between(start, end))
+        .group_by(Table.number)
+    )
+"""
 from __future__ import annotations
 
-from datetime import date, datetime
+from datetime import date
 from pathlib import Path
 from typing import Iterable, List, Tuple
 
@@ -9,7 +32,13 @@ import csv
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
-from ..models import Order, Table, Waiter
+from ..models import (
+    OrdersByDay,
+    OrdersByTable,
+    OrdersByWaiter,
+    Table,
+    Waiter,
+)
 
 
 class ReportService:
@@ -18,42 +47,26 @@ class ReportService:
 
     def sales_by_day(self, start: date, end: date) -> List[Tuple[date, int]]:
         stmt = (
-            select(func.date(Order.closed_at), func.sum(Order.total_cents))
-            .where(
-                Order.status == "closed",
-                Order.closed_at.is_not(None),
-                Order.closed_at >= datetime.combine(start, datetime.min.time()),
-                Order.closed_at <= datetime.combine(end, datetime.max.time()),
-            )
-            .group_by(func.date(Order.closed_at))
-            .order_by(func.date(Order.closed_at))
+            select(OrdersByDay.date, OrdersByDay.total_cents)
+            .where(OrdersByDay.date >= start, OrdersByDay.date <= end)
+            .order_by(OrdersByDay.date)
         )
         return [(row[0], row[1] or 0) for row in self.session.execute(stmt)]
 
     def sales_by_waiter(self, start: date, end: date) -> List[Tuple[str, int]]:
         stmt = (
-            select(Waiter.name, func.sum(Order.total_cents))
-            .join(Order.waiter)
-            .where(
-                Order.status == "closed",
-                Order.closed_at.is_not(None),
-                Order.closed_at >= datetime.combine(start, datetime.min.time()),
-                Order.closed_at <= datetime.combine(end, datetime.max.time()),
-            )
+            select(Waiter.name, func.sum(OrdersByWaiter.total_cents))
+            .join(OrdersByWaiter, OrdersByWaiter.waiter_id == Waiter.id)
+            .where(OrdersByWaiter.date >= start, OrdersByWaiter.date <= end)
             .group_by(Waiter.name)
         )
         return [(row[0], row[1] or 0) for row in self.session.execute(stmt)]
 
     def sales_by_table(self, start: date, end: date) -> List[Tuple[int, int]]:
         stmt = (
-            select(Table.number, func.sum(Order.total_cents))
-            .join(Order.table)
-            .where(
-                Order.status == "closed",
-                Order.closed_at.is_not(None),
-                Order.closed_at >= datetime.combine(start, datetime.min.time()),
-                Order.closed_at <= datetime.combine(end, datetime.max.time()),
-            )
+            select(Table.number, func.sum(OrdersByTable.total_cents))
+            .join(OrdersByTable, OrdersByTable.table_id == Table.id)
+            .where(OrdersByTable.date >= start, OrdersByTable.date <= end)
             .group_by(Table.number)
         )
         return [(row[0], row[1] or 0) for row in self.session.execute(stmt)]

--- a/app/services/table_service.py
+++ b/app/services/table_service.py
@@ -8,7 +8,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from ..event_bus import event_bus
-from ..models import Order, Table
+from ..models import Order, OrdersByDay, OrdersByTable, OrdersByWaiter, Table
 from .exceptions import DomainError
 
 
@@ -70,6 +70,7 @@ class TableService:
         order.closed_at = datetime.utcnow()
         table.current_order_id = None
         table.status = "free"
+        self._update_order_aggregations(order)
         self.session.flush()
         event_bus.publish("table_status_changed", {"table_id": table.id, "status": table.status})
         return order
@@ -79,3 +80,45 @@ class TableService:
         table.status = "occupied"
         self.session.flush()
         event_bus.publish("table_status_changed", {"table_id": table.id, "status": table.status})
+
+    def _update_order_aggregations(self, order: Order) -> None:
+        """Persist aggregated totals for a closed order."""
+
+        if order.status != "closed":  # Safety net for callers
+            return
+
+        order_date = (order.closed_at or datetime.utcnow()).date()
+        total_cents = order.total_cents
+
+        day_row = self.session.get(OrdersByDay, order_date)
+        if not day_row:
+            day_row = OrdersByDay(date=order_date, total_orders=0, total_cents=0)
+            self.session.add(day_row)
+        day_row.total_orders += 1
+        day_row.total_cents += total_cents
+
+        waiter_key = (order_date, order.waiter_id)
+        waiter_row = self.session.get(OrdersByWaiter, waiter_key)
+        if not waiter_row:
+            waiter_row = OrdersByWaiter(
+                date=order_date,
+                waiter_id=order.waiter_id,
+                total_orders=0,
+                total_cents=0,
+            )
+            self.session.add(waiter_row)
+        waiter_row.total_orders += 1
+        waiter_row.total_cents += total_cents
+
+        table_key = (order_date, order.table_id)
+        table_row = self.session.get(OrdersByTable, table_key)
+        if not table_row:
+            table_row = OrdersByTable(
+                date=order_date,
+                table_id=order.table_id,
+                total_orders=0,
+                total_cents=0,
+            )
+            self.session.add(table_row)
+        table_row.total_orders += 1
+        table_row.total_cents += total_cents


### PR DESCRIPTION
## Summary
- add persistent aggregation models for orders grouped by day, waiter, and table
- update the table close workflow to upsert aggregate totals when an order is closed
- refresh the reporting service to query the new aggregation tables and document example usage

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68dc650a96e08325890d17257e020298