### PR TITLE
feat: refresh login and management interfaces

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -83,6 +83,7 @@ class MenuItem(Base):
     price_cents: Mapped[int] = mapped_column(Integer, nullable=False)
     description: Mapped[Optional[str]] = mapped_column(Text)
     is_active: Mapped[bool] = mapped_column(default=True)
+    image_path: Mapped[Optional[str]] = mapped_column(String(300))
 
     category: Mapped[Category] = relationship(back_populates="menu_items")
     order_items: Mapped[List["OrderItem"]] = relationship(back_populates="menu_item")

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -6,6 +6,7 @@ from .order_service import OrderService
 from .report_service import ReportService
 from .table_service import TableService
 from .ticket_service import TicketService
+from .waiter_service import WaiterService
 
 __all__ = [
     "AuthService",
@@ -16,5 +17,6 @@ __all__ = [
     "ReportService",
     "TableService",
     "TicketService",
+    "WaiterService",
     "ValidationError",
 ]

--- a/app/services/menu_service.py
+++ b/app/services/menu_service.py
@@ -71,6 +71,7 @@ class MenuService:
         price_cents: int,
         description: Optional[str] = None,
         is_active: bool = True,
+        image_path: Optional[str] = None,
     ) -> MenuItem:
         if price_cents < 0:
             raise ValidationError("El precio no puede ser negativo")
@@ -80,6 +81,7 @@ class MenuService:
             price_cents=price_cents,
             description=description,
             is_active=is_active,
+            image_path=image_path,
         )
         self.session.add(item)
         self.session.flush()
@@ -89,7 +91,7 @@ class MenuService:
         item = self.session.get(MenuItem, item_id)
         if not item:
             raise ValidationError("Platillo no encontrado")
-        for field in ("name", "price_cents", "description", "is_active", "category_id"):
+        for field in ("name", "price_cents", "description", "is_active", "category_id", "image_path"):
             if field in kwargs and kwargs[field] is not None:
                 if field == "price_cents" and kwargs[field] < 0:
                     raise ValidationError("El precio no puede ser negativo")

--- a/app/services/waiter_service.py
+++ b/app/services/waiter_service.py
@@ -1,0 +1,65 @@
+"""Service helpers for employee management."""
+from __future__ import annotations
+
+from typing import List
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from ..models import Waiter
+from .exceptions import ValidationError
+
+
+class WaiterService:
+    """CRUD utilities for managing restaurant employees."""
+
+    def __init__(self, session: Session) -> None:
+        self.session = session
+
+    def list_waiters(self, include_managers: bool = True) -> List[Waiter]:
+        stmt = select(Waiter).where(Waiter.is_active.is_(True))
+        if not include_managers:
+            stmt = stmt.where(Waiter.is_manager.is_(False))
+        stmt = stmt.order_by(Waiter.name)
+        return list(self.session.scalars(stmt))
+
+    def create_waiter(self, name: str, pin: str, *, is_manager: bool = False) -> Waiter:
+        name = (name or "").strip()
+        pin = (pin or "").strip()
+        if not name:
+            raise ValidationError("El nombre es obligatorio")
+        if not pin or len(pin) < 4:
+            raise ValidationError("El PIN debe tener al menos 4 dígitos")
+        existing = self.session.scalar(select(Waiter).where(Waiter.pin == pin))
+        if existing:
+            raise ValidationError("Ya existe un empleado con ese PIN")
+        waiter = Waiter(name=name, pin=pin, is_manager=is_manager, is_active=True)
+        self.session.add(waiter)
+        self.session.flush()
+        return waiter
+
+    def update_pin(self, waiter_id: int, new_pin: str) -> Waiter:
+        new_pin = (new_pin or "").strip()
+        if not new_pin or len(new_pin) < 4:
+            raise ValidationError("El PIN debe tener al menos 4 dígitos")
+        waiter = self.session.get(Waiter, waiter_id)
+        if not waiter or not waiter.is_active:
+            raise ValidationError("Empleado no encontrado")
+        if waiter.is_manager:
+            raise ValidationError("No se puede modificar el PIN del encargado principal")
+        existing = self.session.scalar(
+            select(Waiter).where(Waiter.pin == new_pin, Waiter.id != waiter_id)
+        )
+        if existing:
+            raise ValidationError("Ese PIN ya está asignado a otro empleado")
+        waiter.pin = new_pin
+        self.session.flush()
+        return waiter
+
+    def delete_waiter(self, waiter_id: int) -> None:
+        waiter = self.session.get(Waiter, waiter_id)
+        if not waiter or not waiter.is_active:
+            raise ValidationError("Empleado no encontrado")
+        if waiter.is_manager:
+            raise ValidationError("No se puede eliminar a los encargados")
+        self.session.delete(waiter)

--- a/app/styles.qss
+++ b/app/styles.qss
@@ -18,6 +18,12 @@ QWidget#dialogCard {
     border-radius: 28px;
 }
 
+QWidget#formCard {
+    background-color: #ffffff;
+    border-radius: 24px;
+    border: 2px solid #e3f2fd;
+}
+
 QWidget#dialogCard {
     min-width: 360px;
 }
@@ -35,6 +41,12 @@ QLabel#subtitleLabel {
 }
 
 QLabel#sectionTitle {
+    color: #0d47a1;
+    font-size: 20px;
+    font-weight: 600;
+}
+
+QLabel#categoryLabel {
     color: #0d47a1;
     font-size: 20px;
     font-weight: 600;
@@ -91,6 +103,31 @@ QSpinBox#quantitySpin {
 QSpinBox#quantitySpin:focus {
     border: 2px solid #1e88e5;
     background: #ffffff;
+}
+
+QDoubleSpinBox#priceSpin,
+QComboBox#comboInput {
+    padding: 14px 16px;
+    border-radius: 16px;
+    border: 2px solid #d6e4ff;
+    background: #f7faff;
+    font-size: 16px;
+}
+
+QDoubleSpinBox#priceSpin:focus,
+QComboBox#comboInput:focus {
+    border: 2px solid #1e88e5;
+    background: #ffffff;
+}
+
+QComboBox#comboInput::drop-down {
+    border: none;
+    width: 32px;
+}
+
+QComboBox#comboInput::down-arrow {
+    image: none;
+    background: transparent;
 }
 
 QPushButton#primaryButton,
@@ -151,10 +188,37 @@ QPushButton#menuItemButton:pressed {
     color: #0d47a1;
 }
 
+QPushButton#heroButton {
+    background-color: #0d47a1;
+    color: #ffffff;
+    border-radius: 32px;
+    padding: 24px 36px;
+    font-size: 20px;
+    font-weight: 700;
+    border: none;
+}
+
+QPushButton#heroButton:hover {
+    background-color: #1565c0;
+}
+
+QPushButton#heroButton:pressed {
+    background-color: #bbdefb;
+    color: #0d47a1;
+}
+
 QListWidget#cartList {
     border: none;
     background: #f7faff;
     border-radius: 20px;
+    padding: 12px;
+}
+
+QListWidget#managerList,
+QListWidget#employeeList {
+    background: #f7faff;
+    border: 2px solid #d6e4ff;
+    border-radius: 18px;
     padding: 12px;
 }
 
@@ -198,4 +262,42 @@ QScrollBar::handle:vertical {
 QScrollBar::add-line:vertical,
 QScrollBar::sub-line:vertical {
     height: 0;
+}
+
+QScrollArea#menuScroll {
+    border: none;
+    background: transparent;
+}
+
+QScrollArea#menuScroll > QWidget > QWidget {
+    background: transparent;
+}
+
+QFrame#productCard {
+    background: #f7faff;
+    border-radius: 24px;
+    border: 2px solid transparent;
+}
+
+QFrame#productCard[selected="true"] {
+    border-color: #1565c0;
+    background: #e3f2fd;
+}
+
+QLabel#productName {
+    font-size: 16px;
+    font-weight: 600;
+    color: #0d47a1;
+}
+
+QLabel#productPrice {
+    font-size: 18px;
+    font-weight: 600;
+    color: #1565c0;
+}
+
+QLabel#productImage,
+QLabel#imagePreview {
+    background: #e3f2fd;
+    border-radius: 20px;
 }

--- a/app/ui/components/product_card.py
+++ b/app/ui/components/product_card.py
@@ -1,0 +1,91 @@
+"""Reusable product cards with image and price."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtGui import QPixmap
+from PyQt6.QtWidgets import QFrame, QLabel, QVBoxLayout
+
+
+class ProductCard(QFrame):
+    """Stylized card that displays product information."""
+
+    clicked = pyqtSignal()
+
+    def __init__(
+        self,
+        *,
+        title: str,
+        price_text: str,
+        image_path: Optional[str] = None,
+        parent=None,
+    ) -> None:
+        super().__init__(parent)
+        self.setObjectName("productCard")
+        self.setCursor(Qt.CursorShape.PointingHandCursor)
+        self._selected = False
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(16, 16, 16, 16)
+        layout.setSpacing(12)
+
+        self.image_label = QLabel()
+        self.image_label.setObjectName("productImage")
+        self.image_label.setFixedSize(160, 120)
+        self.image_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(self.image_label, alignment=Qt.AlignmentFlag.AlignCenter)
+
+        self.title_label = QLabel(title)
+        self.title_label.setObjectName("productName")
+        self.title_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.title_label.setWordWrap(True)
+        layout.addWidget(self.title_label)
+
+        self.price_label = QLabel(price_text)
+        self.price_label.setObjectName("productPrice")
+        self.price_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(self.price_label)
+
+        layout.addStretch(1)
+        self.setMinimumSize(180, 220)
+        self._apply_image(image_path)
+
+    def set_selected(self, value: bool) -> None:
+        self._selected = value
+        self.setProperty("selected", value)
+        self.style().unpolish(self)
+        self.style().polish(self)
+
+    def is_selected(self) -> bool:
+        return self._selected
+
+    def update_content(self, *, title: Optional[str] = None, price_text: Optional[str] = None) -> None:
+        if title is not None:
+            self.title_label.setText(title)
+        if price_text is not None:
+            self.price_label.setText(price_text)
+
+    def set_image(self, image_path: Optional[str]) -> None:
+        self._apply_image(image_path)
+
+    def _apply_image(self, image_path: Optional[str]) -> None:
+        pixmap = QPixmap()
+        if image_path:
+            candidate = Path(image_path)
+            if candidate.exists():
+                pixmap = QPixmap(str(candidate))
+        if pixmap.isNull():
+            pixmap = QPixmap(160, 120)
+            pixmap.fill(Qt.GlobalColor.lightGray)
+        self.image_label.setPixmap(pixmap.scaled(
+            self.image_label.size(),
+            Qt.AspectRatioMode.KeepAspectRatioByExpanding,
+            Qt.TransformationMode.SmoothTransformation,
+        ))
+
+    def mousePressEvent(self, event) -> None:  # type: ignore[override]
+        if event.button() == Qt.MouseButton.LeftButton:
+            self.clicked.emit()
+        super().mousePressEvent(event)

--- a/app/ui/dialogs/__init__.py
+++ b/app/ui/dialogs/__init__.py
@@ -1,0 +1,1 @@
+"""Dialog helpers for Meserito UI."""

--- a/app/ui/dialogs/add_product_dialog.py
+++ b/app/ui/dialogs/add_product_dialog.py
@@ -1,0 +1,196 @@
+"""Dialog to browse the menu in a touch-friendly way."""
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QColor
+from PyQt6.QtWidgets import (
+    QComboBox,
+    QDialog,
+    QGraphicsDropShadowEffect,
+    QGridLayout,
+    QHBoxLayout,
+    QLabel,
+    QMessageBox,
+    QPushButton,
+    QScrollArea,
+    QSpinBox,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ...models import Category
+from ...services import MenuService
+from ...viewmodels import MenuItemInfo
+from ..components.product_card import ProductCard
+
+
+class AddProductDialog(QDialog):
+    """Touch friendly dialog to add products to an order."""
+
+    def __init__(self, session_factory, parent=None) -> None:
+        super().__init__(parent)
+        self.session_factory = session_factory
+        self.setModal(True)
+        self.setWindowTitle("Añadir producto")
+        self.setObjectName("addProductDialog")
+        self._items_by_category: Dict[int, List[MenuItemInfo]] = {}
+        self._selected_item: Optional[MenuItemInfo] = None
+        self._card_map: Dict[int, ProductCard] = {}
+
+        root_layout = QVBoxLayout(self)
+        root_layout.setContentsMargins(0, 0, 0, 0)
+
+        card = QWidget()
+        card.setObjectName("dialogCard")
+        card_layout = QVBoxLayout(card)
+        card_layout.setContentsMargins(32, 32, 32, 32)
+        card_layout.setSpacing(20)
+
+        title = QLabel("Selecciona un producto")
+        title.setObjectName("sectionTitle")
+        title.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+        subtitle = QLabel("Navega por las categorías y elige el platillo para agregarlo al pedido")
+        subtitle.setObjectName("sectionSubtitle")
+        subtitle.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        subtitle.setWordWrap(True)
+
+        self.category_combo = QComboBox()
+        self.category_combo.setObjectName("comboInput")
+        self.category_combo.currentIndexChanged.connect(self._render_products)
+
+        self.scroll_area = QScrollArea()
+        self.scroll_area.setWidgetResizable(True)
+        self.scroll_area.setObjectName("menuScroll")
+        self.products_widget = QWidget()
+        self.products_layout = QGridLayout(self.products_widget)
+        self.products_layout.setSpacing(18)
+        self.products_layout.setContentsMargins(12, 12, 12, 12)
+        self.scroll_area.setWidget(self.products_widget)
+
+        quantity_label = QLabel("Cantidad")
+        quantity_label.setObjectName("promptLabel")
+        self.quantity_spin = QSpinBox()
+        self.quantity_spin.setObjectName("quantitySpin")
+        self.quantity_spin.setRange(1, 20)
+        self.quantity_spin.setValue(1)
+
+        buttons_layout = QHBoxLayout()
+        buttons_layout.setSpacing(16)
+
+        back_btn = QPushButton("Atrás")
+        back_btn.setObjectName("secondaryButton")
+        back_btn.clicked.connect(self.reject)
+
+        confirm_btn = QPushButton("Confirmar")
+        confirm_btn.setObjectName("primaryButton")
+        confirm_btn.clicked.connect(self._confirm_selection)
+
+        buttons_layout.addWidget(back_btn)
+        buttons_layout.addWidget(confirm_btn)
+
+        card_layout.addWidget(title)
+        card_layout.addWidget(subtitle)
+        card_layout.addWidget(self.category_combo)
+        card_layout.addWidget(self.scroll_area, stretch=1)
+        card_layout.addWidget(quantity_label)
+        card_layout.addWidget(self.quantity_spin)
+        card_layout.addLayout(buttons_layout)
+
+        shadow = QGraphicsDropShadowEffect(self)
+        shadow.setBlurRadius(36)
+        shadow.setOffset(0, 18)
+        shadow.setColor(QColor(30, 136, 229, 70))
+        card.setGraphicsEffect(shadow)
+
+        root_layout.addWidget(card)
+
+        self.resize(720, 640)
+        self._load_menu()
+
+    def selected_item(self) -> Optional[MenuItemInfo]:
+        return self._selected_item
+
+    def quantity(self) -> int:
+        return self.quantity_spin.value()
+
+    # Internal helpers
+    def _load_menu(self) -> None:
+        session = self.session_factory()
+        categories: List[Category]
+        try:
+            service = MenuService(session)
+            categories = service.list_categories(active_only=True)
+            self._items_by_category = {
+                category.id: [
+                    MenuItemInfo(
+                        id=item.id,
+                        name=item.name,
+                        price_cents=item.price_cents,
+                        category_id=item.category_id,
+                        image_path=item.image_path,
+                    )
+                    for item in service.list_items(category_id=category.id)
+                ]
+                for category in categories
+            }
+        finally:
+            session.close()
+        self._populate_categories(categories)
+
+    def _populate_categories(self, categories: List[Category]) -> None:
+        self.category_combo.blockSignals(True)
+        self.category_combo.clear()
+        for category in categories:
+            self.category_combo.addItem(category.name, category.id)
+        self.category_combo.blockSignals(False)
+        if categories:
+            self._render_products(0)
+
+    def _render_products(self, index: int) -> None:
+        self._card_map.clear()
+        while self.products_layout.count():
+            item = self.products_layout.takeAt(0)
+            widget = item.widget()
+            if widget:
+                widget.setParent(None)
+        category_id = self.category_combo.currentData()
+        if category_id is None:
+            return
+        products = self._items_by_category.get(category_id, [])
+        row = col = 0
+        for info in products:
+            card = ProductCard(
+                title=info.name,
+                price_text=f"${info.price_cents / 100:.2f}",
+                image_path=info.image_path,
+            )
+            card.clicked.connect(lambda checked=False, data=info: self._select_item(data))
+            self.products_layout.addWidget(card, row, col)
+            self._card_map[info.id] = card
+            col += 1
+            if col >= 3:
+                col = 0
+                row += 1
+        self.products_layout.setRowStretch(row + 1, 1)
+        self._selected_item = None
+        self.quantity_spin.setValue(1)
+
+    def _select_item(self, info: MenuItemInfo) -> None:
+        self._selected_item = info
+        for card in self._card_map.values():
+            card.set_selected(False)
+        card = self._card_map.get(info.id)
+        if card:
+            card.set_selected(True)
+
+    def _confirm_selection(self) -> None:
+        if not self._selected_item:
+            QMessageBox.warning(self, "Meserito", "Selecciona un producto antes de continuar")
+            return
+        if self.quantity_spin.value() <= 0:
+            QMessageBox.warning(self, "Meserito", "La cantidad debe ser mayor a cero")
+            return
+        self.accept()

--- a/app/ui/viewmodels.py
+++ b/app/ui/viewmodels.py
@@ -1,0 +1,16 @@
+"""Lightweight view models shared by the UI layer."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class MenuItemInfo:
+    """Snapshot of a menu item used by the presentation layer."""
+
+    id: int
+    name: str
+    price_cents: int
+    category_id: int
+    image_path: Optional[str] = None

--- a/app/ui/windows/employee_management_dialog.py
+++ b/app/ui/windows/employee_management_dialog.py
@@ -1,0 +1,246 @@
+"""Dialog for managing waiters and their PINs."""
+from __future__ import annotations
+
+from typing import List
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QColor
+from PyQt6.QtWidgets import (
+    QDialog,
+    QFormLayout,
+    QGraphicsDropShadowEffect,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QListWidgetItem,
+    QMessageBox,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ...services import WaiterService
+
+
+class EmployeeManagementDialog(QDialog):
+    """Provides a friendly interface to add or remove waiters."""
+
+    def __init__(self, session_factory, parent=None) -> None:
+        super().__init__(parent)
+        self.session_factory = session_factory
+        self.setModal(True)
+        self.setWindowTitle("Gestionar empleados")
+        self.setObjectName("employeeDialog")
+
+        root_layout = QVBoxLayout(self)
+        root_layout.setContentsMargins(0, 0, 0, 0)
+
+        card = QWidget()
+        card.setObjectName("dialogCard")
+        card_layout = QHBoxLayout(card)
+        card_layout.setContentsMargins(32, 32, 32, 32)
+        card_layout.setSpacing(24)
+
+        # Employee list
+        list_container = QVBoxLayout()
+        list_title = QLabel("Empleados activos")
+        list_title.setObjectName("sectionTitle")
+
+        self.employee_list = QListWidget()
+        self.employee_list.setObjectName("employeeList")
+        self.employee_list.currentItemChanged.connect(self._update_actions)
+
+        list_container.addWidget(list_title)
+        list_container.addWidget(self.employee_list)
+
+        # Forms
+        form_container = QVBoxLayout()
+        form_container.setSpacing(20)
+
+        add_title = QLabel("Añadir mesero")
+        add_title.setObjectName("sectionSubtitle")
+
+        add_form = QWidget()
+        add_form.setObjectName("formCard")
+        add_layout = QFormLayout(add_form)
+        add_layout.setContentsMargins(24, 24, 24, 24)
+        add_layout.setSpacing(16)
+
+        self.name_edit = QLineEdit()
+        self.name_edit.setObjectName("userInput")
+        self.name_edit.setPlaceholderText("Nombre del empleado")
+
+        self.pin_edit = QLineEdit()
+        self.pin_edit.setObjectName("pinInput")
+        self.pin_edit.setPlaceholderText("PIN de acceso")
+        self.pin_edit.setEchoMode(QLineEdit.EchoMode.Password)
+
+        add_layout.addRow("Nombre", self.name_edit)
+        add_layout.addRow("PIN", self.pin_edit)
+
+        self.add_button = QPushButton("Agregar empleado")
+        self.add_button.setObjectName("primaryButton")
+        self.add_button.clicked.connect(self._add_employee)
+
+        add_form_layout = QVBoxLayout()
+        add_form_layout.setContentsMargins(0, 0, 0, 0)
+        add_form_layout.setSpacing(16)
+        add_form_layout.addWidget(add_title)
+        add_form_layout.addWidget(add_form)
+        add_form_layout.addWidget(self.add_button, alignment=Qt.AlignmentFlag.AlignRight)
+
+        form_container.addLayout(add_form_layout)
+
+        update_title = QLabel("Actualizar PIN")
+        update_title.setObjectName("sectionSubtitle")
+
+        update_form = QWidget()
+        update_form.setObjectName("formCard")
+        update_layout = QFormLayout(update_form)
+        update_layout.setContentsMargins(24, 24, 24, 24)
+        update_layout.setSpacing(16)
+
+        self.new_pin_edit = QLineEdit()
+        self.new_pin_edit.setObjectName("pinInput")
+        self.new_pin_edit.setPlaceholderText("Nuevo PIN")
+        self.new_pin_edit.setEchoMode(QLineEdit.EchoMode.Password)
+
+        update_layout.addRow("Nuevo PIN", self.new_pin_edit)
+
+        self.update_button = QPushButton("Cambiar PIN")
+        self.update_button.setObjectName("primaryButton")
+        self.update_button.clicked.connect(self._change_pin)
+
+        update_form_layout = QVBoxLayout()
+        update_form_layout.setContentsMargins(0, 0, 0, 0)
+        update_form_layout.setSpacing(16)
+        update_form_layout.addWidget(update_title)
+        update_form_layout.addWidget(update_form)
+        update_form_layout.addWidget(self.update_button, alignment=Qt.AlignmentFlag.AlignRight)
+
+        form_container.addLayout(update_form_layout)
+
+        self.delete_button = QPushButton("Eliminar mesero")
+        self.delete_button.setObjectName("secondaryButton")
+        self.delete_button.clicked.connect(self._delete_employee)
+
+        form_container.addWidget(self.delete_button, alignment=Qt.AlignmentFlag.AlignRight)
+        form_container.addStretch(1)
+
+        card_layout.addLayout(list_container, 1)
+        card_layout.addLayout(form_container, 1)
+
+        shadow = QGraphicsDropShadowEffect(self)
+        shadow.setBlurRadius(36)
+        shadow.setOffset(0, 18)
+        shadow.setColor(QColor(30, 136, 229, 70))
+        card.setGraphicsEffect(shadow)
+
+        root_layout.addWidget(card)
+        self.resize(900, 540)
+
+        self._load_employees()
+        self._update_actions()
+
+    def _load_employees(self) -> None:
+        session = self.session_factory()
+        waiters: List[Waiter]
+        try:
+            service = WaiterService(session)
+            waiters = service.list_waiters(include_managers=True)
+        finally:
+            session.close()
+        self.employee_list.clear()
+        for waiter in waiters:
+            label = f"{waiter.name} - {'Encargado' if waiter.is_manager else 'Mesero'}"
+            item = QListWidgetItem(label)
+            item.setData(Qt.ItemDataRole.UserRole, waiter.id)
+            item.setData(Qt.ItemDataRole.UserRole + 1, waiter.is_manager)
+            self.employee_list.addItem(item)
+
+    def _selected_waiter(self) -> tuple[int, bool] | None:
+        item = self.employee_list.currentItem()
+        if not item:
+            return None
+        waiter_id = item.data(Qt.ItemDataRole.UserRole)
+        is_manager = item.data(Qt.ItemDataRole.UserRole + 1)
+        if waiter_id is None:
+            return None
+        return int(waiter_id), bool(is_manager)
+
+    def _add_employee(self) -> None:
+        name = self.name_edit.text()
+        pin = self.pin_edit.text()
+        session = self.session_factory()
+        try:
+            service = WaiterService(session)
+            service.create_waiter(name, pin)
+            session.commit()
+            QMessageBox.information(self, "Meserito", "Empleado agregado correctamente")
+        except Exception as exc:
+            session.rollback()
+            QMessageBox.critical(self, "Meserito", str(exc))
+            return
+        finally:
+            session.close()
+        self.name_edit.clear()
+        self.pin_edit.clear()
+        self._load_employees()
+
+    def _change_pin(self) -> None:
+        selected = self._selected_waiter()
+        if not selected:
+            QMessageBox.warning(self, "Meserito", "Seleccione un mesero")
+            return
+        waiter_id, _ = selected
+        new_pin = self.new_pin_edit.text()
+        session = self.session_factory()
+        try:
+            service = WaiterService(session)
+            service.update_pin(waiter_id, new_pin)
+            session.commit()
+            QMessageBox.information(self, "Meserito", "PIN actualizado")
+        except Exception as exc:
+            session.rollback()
+            QMessageBox.critical(self, "Meserito", str(exc))
+            return
+        finally:
+            session.close()
+        self.new_pin_edit.clear()
+        self._load_employees()
+
+    def _delete_employee(self) -> None:
+        selected = self._selected_waiter()
+        if not selected:
+            QMessageBox.warning(self, "Meserito", "Seleccione un mesero")
+            return
+        waiter_id, _ = selected
+        answer = QMessageBox.question(
+            self,
+            "Meserito",
+            "¿Seguro que desea eliminar al mesero seleccionado?",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+        )
+        if answer != QMessageBox.StandardButton.Yes:
+            return
+        session = self.session_factory()
+        try:
+            service = WaiterService(session)
+            service.delete_waiter(waiter_id)
+            session.commit()
+            QMessageBox.information(self, "Meserito", "Mesero eliminado")
+        except Exception as exc:
+            session.rollback()
+            QMessageBox.critical(self, "Meserito", str(exc))
+            return
+        finally:
+            session.close()
+        self._load_employees()
+
+    def _update_actions(self) -> None:
+        selected = self._selected_waiter()
+        can_edit = bool(selected and not selected[1])
+        self.update_button.setEnabled(can_edit)
+        self.new_pin_edit.setEnabled(can_edit)
+        self.delete_button.setEnabled(can_edit)

--- a/app/ui/windows/login_window.py
+++ b/app/ui/windows/login_window.py
@@ -50,13 +50,6 @@ class LoginWindow(QMainWindow):
         subtitle.setAlignment(Qt.AlignmentFlag.AlignCenter)
         subtitle.setWordWrap(True)
 
-        user_label = QLabel("Código de empleado")
-        user_label.setObjectName("promptLabel")
-
-        self.user_edit = QLineEdit()
-        self.user_edit.setObjectName("userInput")
-        self.user_edit.setPlaceholderText("Ingrese su usuario")
-
         prompt_label = QLabel("Ingrese su PIN")
         prompt_label.setObjectName("promptLabel")
 
@@ -76,8 +69,6 @@ class LoginWindow(QMainWindow):
         card_layout.addWidget(title)
         card_layout.addWidget(subtitle)
         card_layout.addSpacing(10)
-        card_layout.addWidget(user_label)
-        card_layout.addWidget(self.user_edit)
         card_layout.addWidget(prompt_label)
         card_layout.addWidget(self.pin_edit)
         card_layout.addWidget(keypad_btn)
@@ -120,5 +111,4 @@ class LoginWindow(QMainWindow):
         window.show()
         self._child_windows.append(window)
         self.pin_edit.clear()
-        self.user_edit.clear()
 

--- a/app/ui/windows/manager_window.py
+++ b/app/ui/windows/manager_window.py
@@ -5,9 +5,12 @@ from datetime import date
 from pathlib import Path
 
 from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QColor
 from PyQt6.QtWidgets import (
     QDateEdit,
+    QGraphicsDropShadowEffect,
     QHBoxLayout,
+    QLabel,
     QListWidget,
     QListWidgetItem,
     QMainWindow,
@@ -23,6 +26,8 @@ from PyQt6.QtWidgets import (
 from ...models import Category, MenuItem, Table, Waiter
 from ...services import MenuService, ReportService, TableService
 from .floorplan_editor import FloorplanEditor
+from .employee_management_dialog import EmployeeManagementDialog
+from .product_management_dialog import ProductManagementDialog
 
 
 class ManagerWindow(QMainWindow):
@@ -32,8 +37,60 @@ class ManagerWindow(QMainWindow):
         self.session_factory = session_factory
         self.setWindowTitle(f"Meserito - Encargado {manager.name}")
 
-        tabs = QTabWidget()
-        self.setCentralWidget(tabs)
+        self.setMinimumSize(1200, 720)
+
+        central = QWidget()
+        central.setObjectName("backgroundWidget")
+        main_layout = QVBoxLayout(central)
+        main_layout.setContentsMargins(48, 48, 48, 48)
+        main_layout.setSpacing(32)
+
+        title = QLabel("Meserito")
+        title.setObjectName("titleLabel")
+        title.setAlignment(Qt.AlignmentFlag.AlignLeft)
+
+        subtitle = QLabel("Panel de gestión para encargados")
+        subtitle.setObjectName("subtitleLabel")
+        subtitle.setAlignment(Qt.AlignmentFlag.AlignLeft)
+
+        actions_card = QWidget()
+        actions_card.setObjectName("contentCard")
+        actions_layout = QHBoxLayout(actions_card)
+        actions_layout.setContentsMargins(32, 32, 32, 32)
+        actions_layout.setSpacing(24)
+
+        self.employee_button = QPushButton("Gestionar empleados")
+        self.employee_button.setObjectName("heroButton")
+        self.employee_button.setMinimumHeight(72)
+        self.employee_button.clicked.connect(self._open_employee_dialog)
+
+        self.product_button = QPushButton("Gestionar productos")
+        self.product_button.setObjectName("heroButton")
+        self.product_button.setMinimumHeight(72)
+        self.product_button.clicked.connect(self._open_product_dialog)
+
+        actions_layout.addWidget(self.employee_button)
+        actions_layout.addWidget(self.product_button)
+        actions_layout.addStretch(1)
+
+        tabs_card = QWidget()
+        tabs_card.setObjectName("contentCard")
+        tabs_layout = QVBoxLayout(tabs_card)
+        tabs_layout.setContentsMargins(24, 24, 24, 24)
+        tabs_layout.setSpacing(16)
+
+        self.tabs = QTabWidget()
+        self.tabs.setObjectName("managerTabs")
+        tabs_layout.addWidget(self.tabs)
+
+        main_layout.addWidget(title)
+        main_layout.addWidget(subtitle)
+        main_layout.addWidget(actions_card)
+        main_layout.addWidget(tabs_card, 1)
+
+        self.setCentralWidget(central)
+        self._apply_shadow(actions_card)
+        self._apply_shadow(tabs_card)
 
         # Floorplan tab
         floorplan_tab = QWidget()
@@ -42,42 +99,79 @@ class ManagerWindow(QMainWindow):
         self.floorplan.table_moved.connect(self._update_table_position)
         fp_layout.addWidget(self.floorplan)
         add_table_btn = QPushButton("Agregar mesa")
+        add_table_btn.setObjectName("primaryButton")
         add_table_btn.clicked.connect(self._add_table)
-        fp_layout.addWidget(add_table_btn)
-        tabs.addTab(floorplan_tab, "Plano")
+        fp_layout.addWidget(add_table_btn, alignment=Qt.AlignmentFlag.AlignRight)
+        self.tabs.addTab(floorplan_tab, "Plano")
 
         # Menu tab
         menu_tab = QWidget()
         menu_layout = QHBoxLayout(menu_tab)
+        menu_layout.setSpacing(24)
 
-        left = QVBoxLayout()
+        left_panel = QWidget()
+        left_panel.setObjectName("formCard")
+        left_layout = QVBoxLayout(left_panel)
+        left_layout.setContentsMargins(24, 24, 24, 24)
+        left_layout.setSpacing(16)
+
+        categories_title = QLabel("Categorías")
+        categories_title.setObjectName("sectionTitle")
+
         self.category_list = QListWidget()
+        self.category_list.setObjectName("managerList")
         self.category_list.currentItemChanged.connect(lambda *_: self._load_items())
-        left.addWidget(self.category_list)
+
         add_cat = QPushButton("Agregar categoría")
+        add_cat.setObjectName("primaryButton")
         add_cat.clicked.connect(self._add_category)
-        left.addWidget(add_cat)
+
         toggle_cat = QPushButton("Activar/Desactivar")
+        toggle_cat.setObjectName("secondaryButton")
         toggle_cat.clicked.connect(self._toggle_category)
-        left.addWidget(toggle_cat)
 
-        right = QVBoxLayout()
+        left_layout.addWidget(categories_title)
+        left_layout.addWidget(self.category_list, 1)
+        left_layout.addWidget(add_cat)
+        left_layout.addWidget(toggle_cat)
+
+        right_panel = QWidget()
+        right_panel.setObjectName("formCard")
+        right_layout = QVBoxLayout(right_panel)
+        right_layout.setContentsMargins(24, 24, 24, 24)
+        right_layout.setSpacing(16)
+
+        items_title = QLabel("Productos")
+        items_title.setObjectName("sectionTitle")
+
         self.item_list = QListWidget()
-        right.addWidget(self.item_list)
-        add_item = QPushButton("Agregar platillo")
-        add_item.clicked.connect(self._add_item)
-        right.addWidget(add_item)
-        toggle_item = QPushButton("Activar/Desactivar platillo")
-        toggle_item.clicked.connect(self._toggle_item)
-        right.addWidget(toggle_item)
+        self.item_list.setObjectName("managerList")
 
-        menu_layout.addLayout(left)
-        menu_layout.addLayout(right)
-        tabs.addTab(menu_tab, "Menú")
+        add_item = QPushButton("Agregar platillo")
+        add_item.setObjectName("primaryButton")
+        add_item.clicked.connect(self._add_item)
+
+        toggle_item = QPushButton("Activar/Desactivar platillo")
+        toggle_item.setObjectName("secondaryButton")
+        toggle_item.clicked.connect(self._toggle_item)
+
+        right_layout.addWidget(items_title)
+        right_layout.addWidget(self.item_list, 1)
+        right_layout.addWidget(add_item)
+        right_layout.addWidget(toggle_item)
+
+        menu_layout.addWidget(left_panel, 1)
+        menu_layout.addWidget(right_panel, 1)
+        self.tabs.addTab(menu_tab, "Menú")
 
         # Reports tab
         reports_tab = QWidget()
         rep_layout = QVBoxLayout(reports_tab)
+        rep_layout.setSpacing(20)
+
+        reports_title = QLabel("Reportes de ventas")
+        reports_title.setObjectName("sectionTitle")
+
         date_layout = QHBoxLayout()
         self.start_date = QDateEdit()
         self.start_date.setDate(date.today())
@@ -86,19 +180,23 @@ class ManagerWindow(QMainWindow):
         date_layout.addWidget(self.start_date)
         date_layout.addWidget(self.end_date)
         refresh = QPushButton("Generar")
+        refresh.setObjectName("primaryButton")
         refresh.clicked.connect(self._refresh_reports)
         date_layout.addWidget(refresh)
-        rep_layout.addLayout(date_layout)
 
         self.report_table = QTableWidget(0, 3)
         self.report_table.setHorizontalHeaderLabels(["Fecha/Mesero/Mesa", "Total", "Tipo"])
-        rep_layout.addWidget(self.report_table)
 
         export_btn = QPushButton("Exportar CSV")
+        export_btn.setObjectName("secondaryButton")
         export_btn.clicked.connect(self._export_reports)
-        rep_layout.addWidget(export_btn)
 
-        tabs.addTab(reports_tab, "Reportes")
+        rep_layout.addWidget(reports_title)
+        rep_layout.addLayout(date_layout)
+        rep_layout.addWidget(self.report_table, 1)
+        rep_layout.addWidget(export_btn, alignment=Qt.AlignmentFlag.AlignRight)
+
+        self.tabs.addTab(reports_tab, "Reportes")
 
         self._load_tables()
         self._load_categories()
@@ -112,6 +210,23 @@ class ManagerWindow(QMainWindow):
         finally:
             session.close()
         self.floorplan.load_tables(tables)
+
+    def _open_employee_dialog(self) -> None:
+        dialog = EmployeeManagementDialog(self.session_factory, self)
+        dialog.exec()
+
+    def _open_product_dialog(self) -> None:
+        dialog = ProductManagementDialog(self.session_factory, self)
+        dialog.exec()
+        self._load_categories()
+        self._load_items()
+
+    def _apply_shadow(self, widget: QWidget) -> None:
+        shadow = QGraphicsDropShadowEffect(self)
+        shadow.setBlurRadius(36)
+        shadow.setOffset(0, 20)
+        shadow.setColor(QColor(30, 136, 229, 70))
+        widget.setGraphicsEffect(shadow)
 
     def _add_table(self) -> None:
         session = self.session_factory()
@@ -152,6 +267,8 @@ class ManagerWindow(QMainWindow):
             item = QListWidgetItem(f"{category.name} ({'Activo' if category.is_active else 'Inactivo'})")
             item.setData(Qt.ItemDataRole.UserRole, category.id)
             self.category_list.addItem(item)
+        if self.category_list.count() > 0:
+            self.category_list.setCurrentRow(0)
 
     def _load_items(self) -> None:
         current = self.category_list.currentItem()

--- a/app/ui/windows/product_management_dialog.py
+++ b/app/ui/windows/product_management_dialog.py
@@ -1,0 +1,274 @@
+"""Dialog that lets managers curate the restaurant menu."""
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QColor, QPixmap
+from PyQt6.QtWidgets import (
+    QComboBox,
+    QDialog,
+    QDoubleSpinBox,
+    QFileDialog,
+    QGraphicsDropShadowEffect,
+    QGridLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
+    QScrollArea,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ...services import MenuService
+from ...viewmodels import MenuItemInfo
+from ..components.product_card import ProductCard
+
+
+class ProductManagementDialog(QDialog):
+    """Allow managers to add new products with images."""
+
+    def __init__(self, session_factory, parent=None) -> None:
+        super().__init__(parent)
+        self.session_factory = session_factory
+        self.setModal(True)
+        self.setWindowTitle("Gestión de productos")
+        self.setObjectName("productDialog")
+        self.selected_image_path: Optional[str] = None
+        self.categories: List[tuple[int, str]] = []
+        self.products_by_category: Dict[int, List[MenuItemInfo]] = {}
+        self.all_products: List[MenuItemInfo] = []
+
+        root_layout = QVBoxLayout(self)
+        root_layout.setContentsMargins(0, 0, 0, 0)
+
+        card = QWidget()
+        card.setObjectName("dialogCard")
+        card_layout = QHBoxLayout(card)
+        card_layout.setContentsMargins(32, 32, 32, 32)
+        card_layout.setSpacing(24)
+
+        # Form panel
+        form_panel = QWidget()
+        form_panel.setObjectName("formCard")
+        form_layout = QVBoxLayout(form_panel)
+        form_layout.setContentsMargins(24, 24, 24, 24)
+        form_layout.setSpacing(16)
+
+        form_title = QLabel("Añadir nuevo producto")
+        form_title.setObjectName("sectionTitle")
+
+        self.name_edit = QLineEdit()
+        self.name_edit.setObjectName("userInput")
+        self.name_edit.setPlaceholderText("Nombre del producto")
+
+        self.price_spin = QDoubleSpinBox()
+        self.price_spin.setObjectName("priceSpin")
+        self.price_spin.setRange(0.0, 100000.0)
+        self.price_spin.setSuffix(" $")
+        self.price_spin.setDecimals(2)
+        self.price_spin.setSingleStep(5.0)
+
+        self.category_combo = QComboBox()
+        self.category_combo.setObjectName("comboInput")
+
+        self.image_preview = QLabel()
+        self.image_preview.setObjectName("imagePreview")
+        self.image_preview.setFixedSize(220, 160)
+        self.image_preview.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self._update_preview(None)
+
+        image_button = QPushButton("Seleccionar foto")
+        image_button.setObjectName("secondaryButton")
+        image_button.clicked.connect(self._choose_image)
+
+        add_button = QPushButton("Guardar producto")
+        add_button.setObjectName("primaryButton")
+        add_button.clicked.connect(self._save_product)
+        self.add_button = add_button
+
+        form_layout.addWidget(form_title)
+        form_layout.addWidget(self.name_edit)
+        form_layout.addWidget(self.price_spin)
+        form_layout.addWidget(self.category_combo)
+        form_layout.addWidget(self.image_preview, alignment=Qt.AlignmentFlag.AlignCenter)
+        form_layout.addWidget(image_button)
+        form_layout.addStretch(1)
+        form_layout.addWidget(add_button, alignment=Qt.AlignmentFlag.AlignRight)
+
+        # Gallery panel
+        gallery_panel = QWidget()
+        gallery_panel.setObjectName("formCard")
+        gallery_layout = QVBoxLayout(gallery_panel)
+        gallery_layout.setContentsMargins(24, 24, 24, 24)
+        gallery_layout.setSpacing(16)
+
+        gallery_title = QLabel("Productos registrados")
+        gallery_title.setObjectName("sectionTitle")
+
+        self.filter_combo = QComboBox()
+        self.filter_combo.setObjectName("comboInput")
+        self.filter_combo.currentIndexChanged.connect(self._render_products)
+
+        self.scroll_area = QScrollArea()
+        self.scroll_area.setWidgetResizable(True)
+        self.scroll_area.setObjectName("menuScroll")
+        self.grid_widget = QWidget()
+        self.grid_layout = QGridLayout(self.grid_widget)
+        self.grid_layout.setSpacing(18)
+        self.grid_layout.setContentsMargins(0, 0, 0, 0)
+        self.scroll_area.setWidget(self.grid_widget)
+
+        gallery_layout.addWidget(gallery_title)
+        gallery_layout.addWidget(self.filter_combo)
+        gallery_layout.addWidget(self.scroll_area, 1)
+
+        card_layout.addWidget(form_panel, 1)
+        card_layout.addWidget(gallery_panel, 2)
+
+        shadow = QGraphicsDropShadowEffect(self)
+        shadow.setBlurRadius(36)
+        shadow.setOffset(0, 18)
+        shadow.setColor(QColor(30, 136, 229, 70))
+        card.setGraphicsEffect(shadow)
+
+        root_layout.addWidget(card)
+        self.resize(1100, 640)
+
+        self._refresh_data()
+
+    def _refresh_data(self) -> None:
+        session = self.session_factory()
+        try:
+            service = MenuService(session)
+            categories = service.list_categories(active_only=True)
+            self.categories = [(cat.id, cat.name) for cat in categories]
+            self.products_by_category = {}
+            self.all_products = []
+            for cat in categories:
+                items = [
+                    MenuItemInfo(
+                        id=item.id,
+                        name=item.name,
+                        price_cents=item.price_cents,
+                        category_id=item.category_id,
+                        image_path=item.image_path,
+                    )
+                    for item in service.list_items(category_id=cat.id, include_inactive=False)
+                ]
+                self.products_by_category[cat.id] = items
+                self.all_products.extend(items)
+        finally:
+            session.close()
+        self._populate_category_inputs()
+        self._render_products()
+
+    def _populate_category_inputs(self) -> None:
+        self.category_combo.blockSignals(True)
+        self.category_combo.clear()
+        for cat_id, name in self.categories:
+            self.category_combo.addItem(name, cat_id)
+        self.category_combo.blockSignals(False)
+
+        self.filter_combo.blockSignals(True)
+        self.filter_combo.clear()
+        self.filter_combo.addItem("Todos", None)
+        for cat_id, name in self.categories:
+            self.filter_combo.addItem(name, cat_id)
+        self.filter_combo.blockSignals(False)
+
+        if self.categories:
+            self.category_combo.setCurrentIndex(0)
+        self.filter_combo.setCurrentIndex(0)
+
+        has_categories = bool(self.categories)
+        self.category_combo.setEnabled(has_categories)
+        self.add_button.setEnabled(has_categories)
+        if not has_categories:
+            self.category_combo.addItem("Crea una categoría primero", None)
+
+    def _render_products(self) -> None:
+        while self.grid_layout.count():
+            item = self.grid_layout.takeAt(0)
+            widget = item.widget()
+            if widget:
+                widget.deleteLater()
+        category_id = self.filter_combo.currentData()
+        if category_id is None:
+            products = self.all_products
+        else:
+            products = self.products_by_category.get(category_id, [])
+        if not products:
+            empty = QLabel("No hay productos en esta categoría todavía")
+            empty.setObjectName("sectionSubtitle")
+            empty.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            self.grid_layout.addWidget(empty, 0, 0)
+            return
+        for index, info in enumerate(products):
+            card = ProductCard(
+                title=info.name,
+                price_text=f"${info.price_cents / 100:.2f}",
+                image_path=info.image_path,
+            )
+            row = index // 3
+            col = index % 3
+            self.grid_layout.addWidget(card, row, col)
+
+    def _choose_image(self) -> None:
+        path, _ = QFileDialog.getOpenFileName(
+            self,
+            "Seleccionar imagen",
+            "",
+            "Archivos de imagen (*.png *.jpg *.jpeg *.bmp)",
+        )
+        if not path:
+            return
+        self.selected_image_path = path
+        self._update_preview(path)
+
+    def _update_preview(self, path: Optional[str]) -> None:
+        pixmap = QPixmap()
+        if path:
+            pixmap = QPixmap(path)
+        if pixmap.isNull():
+            pixmap = QPixmap(220, 160)
+            pixmap.fill(Qt.GlobalColor.lightGray)
+        self.image_preview.setPixmap(
+            pixmap.scaled(
+                self.image_preview.size(),
+                Qt.AspectRatioMode.KeepAspectRatioByExpanding,
+                Qt.TransformationMode.SmoothTransformation,
+            )
+        )
+
+    def _save_product(self) -> None:
+        name = self.name_edit.text().strip()
+        category_id = self.category_combo.currentData()
+        if not name or category_id is None:
+            QMessageBox.warning(self, "Meserito", "Completa el nombre y selecciona una categoría")
+            return
+        price_cents = int(round(self.price_spin.value() * 100))
+        session = self.session_factory()
+        try:
+            service = MenuService(session)
+            service.create_item(
+                category_id=category_id,
+                name=name,
+                price_cents=price_cents,
+                image_path=self.selected_image_path,
+            )
+            session.commit()
+            QMessageBox.information(self, "Meserito", "Producto guardado")
+        except Exception as exc:
+            session.rollback()
+            QMessageBox.critical(self, "Meserito", str(exc))
+            return
+        finally:
+            session.close()
+        self.name_edit.clear()
+        self.price_spin.setValue(0.0)
+        self.selected_image_path = None
+        self._update_preview(None)
+        self._refresh_data()

--- a/app/ui/windows/waiter_window.py
+++ b/app/ui/windows/waiter_window.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional
+from typing import Dict, List, Optional
 
 from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QColor
@@ -15,6 +15,7 @@ from PyQt6.QtWidgets import (
     QMainWindow,
     QMessageBox,
     QPushButton,
+    QScrollArea,
     QSpinBox,
     QVBoxLayout,
     QWidget,
@@ -22,17 +23,19 @@ from PyQt6.QtWidgets import (
 )
 
 from ...event_bus import event_bus
-from ...models import MenuItem, Table, Waiter
+from ...models import Table, Waiter
 from ...services import MenuService, OrderService, TableService, TicketService
 from ..components.cart_sidebar import CartSidebar
-from ..components.menu_browser import MenuBrowser
+from ..components.product_card import ProductCard
+from ..dialogs.add_product_dialog import AddProductDialog
 from ..components.table_widget import TableWidget
+from ..viewmodels import MenuItemInfo
 
 
 class QuantityDialog(QDialog):
     """Dialog to request the quantity of a selected product."""
 
-    def __init__(self, menu_item: MenuItem, parent: QWidget | None = None) -> None:
+    def __init__(self, menu_item: MenuItemInfo, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self.menu_item = menu_item
         self.quantity = 1
@@ -107,6 +110,8 @@ class WaiterWindow(QMainWindow):
         self.selected_table_id: Optional[int] = None
         self.current_order_id: Optional[int] = None
         self.table_widgets: dict[int, TableWidget] = {}
+        self.menu_categories: List[tuple[int, str]] = []
+        self.menu_items_by_category: Dict[int, List[MenuItemInfo]] = {}
 
         event_bus.subscribe("table_status_changed", self._handle_table_event)
         event_bus.subscribe("order_updated", self._handle_order_event)
@@ -163,15 +168,30 @@ class WaiterWindow(QMainWindow):
         menu_title = QLabel("Menú del restaurante")
         menu_title.setObjectName("sectionTitle")
 
-        menu_hint = QLabel("Selecciona un producto para agregarlo al pedido")
+        menu_hint = QLabel(
+            "Explora el menú táctil y usa el botón para añadir productos al pedido"
+        )
         menu_hint.setObjectName("sectionSubtitle")
+        menu_hint.setWordWrap(True)
 
-        self.menu_browser = MenuBrowser()
-        self.menu_browser.on_item_selected = self._handle_menu_item
+        self.menu_scroll = QScrollArea()
+        self.menu_scroll.setObjectName("menuScroll")
+        self.menu_scroll.setWidgetResizable(True)
+        self.menu_grid_widget = QWidget()
+        self.menu_grid_layout = QVBoxLayout(self.menu_grid_widget)
+        self.menu_grid_layout.setContentsMargins(0, 0, 0, 0)
+        self.menu_grid_layout.setSpacing(24)
+        self.menu_scroll.setWidget(self.menu_grid_widget)
+
+        self.add_product_button = QPushButton("Añadir producto")
+        self.add_product_button.setObjectName("heroButton")
+        self.add_product_button.setMinimumHeight(64)
+        self.add_product_button.clicked.connect(self._open_add_product_dialog)
 
         menu_layout.addWidget(menu_title)
         menu_layout.addWidget(menu_hint)
-        menu_layout.addWidget(self.menu_browser)
+        menu_layout.addWidget(self.menu_scroll, 1)
+        menu_layout.addWidget(self.add_product_button)
 
         cart_card = QWidget()
         cart_card.setObjectName("contentCard")
@@ -339,25 +359,94 @@ class WaiterWindow(QMainWindow):
         try:
             menu_service = MenuService(session)
             categories = menu_service.list_categories(active_only=True)
-            items = []
-            for cat in categories:
-                items.extend(menu_service.list_items(category_id=cat.id))
+            self.menu_categories = [(cat.id, cat.name) for cat in categories]
+            self.menu_items_by_category = {
+                cat.id: [
+                    MenuItemInfo(
+                        id=item.id,
+                        name=item.name,
+                        price_cents=item.price_cents,
+                        category_id=item.category_id,
+                        image_path=item.image_path,
+                    )
+                    for item in menu_service.list_items(category_id=cat.id)
+                ]
+                for cat in categories
+            }
         finally:
             session.close()
-        self.menu_browser.set_menu(categories, items)
+        self._render_menu()
 
-    def _handle_menu_item(self, menu_item: MenuItem) -> None:
+    def _render_menu(self) -> None:
+        while self.menu_grid_layout.count():
+            item = self.menu_grid_layout.takeAt(0)
+            widget = item.widget()
+            if widget:
+                widget.deleteLater()
+        for category_id, name in self.menu_categories:
+            products = self.menu_items_by_category.get(category_id, [])
+            if not products:
+                continue
+            section = QWidget()
+            section.setObjectName("categorySection")
+            section_layout = QVBoxLayout(section)
+            section_layout.setContentsMargins(0, 0, 0, 0)
+            section_layout.setSpacing(12)
+
+            header = QLabel(name)
+            header.setObjectName("categoryLabel")
+
+            grid_widget = QWidget()
+            grid_layout = QGridLayout(grid_widget)
+            grid_layout.setSpacing(18)
+            grid_layout.setContentsMargins(0, 0, 0, 0)
+
+            for index, info in enumerate(products):
+                card = ProductCard(
+                    title=info.name,
+                    price_text=f"${info.price_cents / 100:.2f}",
+                    image_path=info.image_path,
+                )
+                card.clicked.connect(lambda checked=False, data=info: self._prompt_quantity(data))
+                row = index // 3
+                col = index % 3
+                grid_layout.addWidget(card, row, col)
+
+            section_layout.addWidget(header)
+            section_layout.addWidget(grid_widget)
+            self.menu_grid_layout.addWidget(section)
+
+        self.menu_grid_layout.addStretch(1)
+
+    def _prompt_quantity(self, menu_item: MenuItemInfo) -> None:
         if not self.selected_table_id or not self.current_order_id:
             QMessageBox.warning(self, "Meserito", "Seleccione una mesa y abra un pedido primero")
             return
         dialog = QuantityDialog(menu_item, self)
         if not dialog.exec():
             return
+        self._add_item_to_order(menu_item.id, dialog.quantity)
+
+    def _open_add_product_dialog(self) -> None:
+        if not self.selected_table_id or not self.current_order_id:
+            QMessageBox.warning(self, "Meserito", "Seleccione una mesa y abra un pedido primero")
+            return
+        dialog = AddProductDialog(self.session_factory, self)
+        if not dialog.exec():
+            return
+        selection = dialog.selected_item()
+        if not selection:
+            return
+        self._add_item_to_order(selection.id, dialog.quantity())
+
+    def _add_item_to_order(self, menu_item_id: int, quantity: int) -> None:
+        if not self.current_order_id or not self.selected_table_id:
+            return
         session = self.session_factory()
         try:
             order_service = OrderService(session)
             table_service = TableService(session)
-            order_service.add_item(self.current_order_id, menu_item.id, qty=dialog.quantity)
+            order_service.add_item(self.current_order_id, menu_item_id, qty=quantity)
             order_service.compute_totals(self.current_order_id)
             table_service.mark_occupied(self.selected_table_id)
             session.commit()


### PR DESCRIPTION
## Summary
- simplify the login flow to request only the employee PIN while keeping the refreshed blue and white layout
- redesign the manager experience with hero actions for employee/product management, add dedicated dialogs, and update list styling
- modernize the waiter ordering workflow with a scrollable menu gallery, touch-friendly add-product dialog, reusable product cards, and menu items that store image paths

## Testing
- python -m compileall app
- pytest *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68dc68b58bf48325a61d7405c5af55c4