### PR TITLE
Add Pydantic view models bridging UI and database

### DIFF
--- a/app/viewmodels.py
+++ b/app/viewmodels.py
@@ -1,0 +1,57 @@
+"""Pydantic models bridging SQLAlchemy entities and PyQt views."""
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class OrmViewModel(BaseModel):
+    """Base class for models built from SQLAlchemy entities."""
+
+    class Config:
+        from_attributes = True
+
+
+class MenuItemInfo(OrmViewModel):
+    """Serializable snapshot of a menu item."""
+
+    id: int
+    name: str
+    price_cents: int
+    category_id: int
+    description: Optional[str] = None
+    image_path: Optional[str] = None
+
+
+class WaiterInfo(OrmViewModel):
+    """Details required to identify and authenticate a waiter."""
+
+    id: int
+    name: str
+    pin: str
+    is_manager: bool
+    is_active: bool
+
+
+class TableInfo(OrmViewModel):
+    """Table information shared between the UI and persistence layers."""
+
+    id: int
+    number: int
+    name: Optional[str] = None
+    capacity: int
+    status: str
+
+
+class OrderInfo(OrmViewModel):
+    """Order summary exposed to the presentation layer."""
+
+    id: int
+    table_id: int
+    waiter_id: int
+    covers: int
+    status: str
+    subtotal_cents: int
+    tax_cents: int
+    total_cents: int


### PR DESCRIPTION
## Summary
- add a new `app/viewmodels.py` module that provides Pydantic models for menu items, waiters, tables, and orders
- configure the models for ORM compatibility so they can hydrate directly from SQLAlchemy entities

## Testing
- python -m app.main *(fails: missing system dependency libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68dc71e4b5f08325a959b7a9c3cc9a0e