### PR TITLE
Refresh admin panel styling and apply global theme

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+from PyQt6.QtGui import QColor, QFont, QPalette
 from PyQt6.QtWidgets import QApplication
 from sqlalchemy import select
 
@@ -11,6 +12,68 @@ from .db import Base, SessionLocal, engine
 from .models import Category, MenuItem, Table, Waiter
 from .services import AuthService
 from .ui.windows.login_window import LoginWindow
+
+
+def apply_theme(app: QApplication) -> None:
+    """Apply a bright, legible theme with comfortable control sizes."""
+    palette = QPalette()
+    palette.setColor(QPalette.ColorRole.Window, QColor("#f5f8ff"))
+    palette.setColor(QPalette.ColorRole.WindowText, QColor("#0b1e3f"))
+    palette.setColor(QPalette.ColorRole.Base, QColor("#ffffff"))
+    palette.setColor(QPalette.ColorRole.AlternateBase, QColor("#f0f4ff"))
+    palette.setColor(QPalette.ColorRole.ToolTipBase, QColor("#ffffff"))
+    palette.setColor(QPalette.ColorRole.ToolTipText, QColor("#0b1e3f"))
+    palette.setColor(QPalette.ColorRole.Text, QColor("#0b1e3f"))
+    palette.setColor(QPalette.ColorRole.Button, QColor("#ffffff"))
+    palette.setColor(QPalette.ColorRole.ButtonText, QColor("#0b1e3f"))
+    palette.setColor(QPalette.ColorRole.Highlight, QColor("#1e88e5"))
+    palette.setColor(QPalette.ColorRole.HighlightedText, QColor("#ffffff"))
+    palette.setColor(QPalette.ColorRole.PlaceholderText, QColor(11, 30, 63, 120))
+    app.setPalette(palette)
+
+    base_font = QFont("Poppins", 11)
+    base_font.setStyleStrategy(QFont.StyleStrategy.PreferAntialias)
+    app.setFont(base_font)
+
+    base_stylesheet = """
+    QWidget {
+        font-size: 15px;
+    }
+    QPushButton,
+    QToolButton {
+        min-height: 44px;
+        padding: 12px 20px;
+        border-radius: 14px;
+        font-size: 15px;
+    }
+    QPushButton:disabled,
+    QToolButton:disabled {
+        opacity: 0.6;
+    }
+    QTabBar::tab {
+        min-height: 40px;
+        padding: 10px 18px;
+        font-size: 15px;
+        border-radius: 12px;
+        margin: 0 4px;
+    }
+    QTabBar::tab:selected {
+        background: #ffffff;
+        color: #1565c0;
+    }
+    QTabWidget::pane {
+        border: 1px solid #d7e3ff;
+        border-radius: 16px;
+        background: #ffffff;
+        padding: 8px;
+    }
+    """
+
+    stylesheet_path = Path(__file__).resolve().parent / "styles.qss"
+    styles = [base_stylesheet]
+    if stylesheet_path.exists():
+        styles.append(stylesheet_path.read_text(encoding="utf-8"))
+    app.setStyleSheet("\n".join(styles))
 
 
 def seed_database() -> None:
@@ -69,9 +132,7 @@ def main() -> int:
     seed_database()
 
     app = QApplication(sys.argv)
-    stylesheet_path = Path(__file__).resolve().parent / "styles.qss"
-    if stylesheet_path.exists():
-        app.setStyleSheet(stylesheet_path.read_text(encoding="utf-8"))
+    apply_theme(app)
     session = SessionLocal()
     auth_service = AuthService(session)
     window = LoginWindow(auth_service, SessionLocal)

--- a/app/styles.qss
+++ b/app/styles.qss
@@ -7,6 +7,25 @@ QMainWindow {
     background-color: #edf3ff;
 }
 
+QWidget#AdminPanel {
+    background: #f5f8ff;
+    border-radius: 32px;
+}
+
+QWidget#AdminPanel QLabel {
+    color: #0b1e3f;
+}
+
+QWidget#AdminPanel QLabel#titleLabel {
+    font-size: 32px;
+    font-weight: 700;
+}
+
+QWidget#AdminPanel QLabel#subtitleLabel {
+    font-size: 16px;
+    color: #345b97;
+}
+
 QWidget#posBackground,
 QWidget#backgroundWidget {
     background: qlineargradient(
@@ -27,8 +46,8 @@ QPushButton#sidebarButton {
     border: none;
     color: #1a3c80;
     font-weight: 600;
-    font-size: 14px;
-    padding: 12px 8px;
+    font-size: 15px;
+    padding: 14px 10px;
     border-radius: 18px;
     text-align: left;
 }
@@ -50,6 +69,49 @@ QWidget#dialogCard {
     background: #ffffff;
     border-radius: 28px;
     border: 1px solid #d7e3ff;
+}
+
+QWidget#AdminCard {
+    background: #ffffff;
+    border-radius: 12px;
+    border: 1px solid #d4e0f4;
+    padding: 24px;
+}
+
+QWidget#AdminPanel QTabBar::tab {
+    background: transparent;
+    border: none;
+    color: #3f5f94;
+}
+
+QWidget#AdminPanel QTabBar::tab:selected {
+    background: #ffffff;
+    border: 1px solid #cddbf3;
+    color: #1565c0;
+}
+
+QWidget#AdminPanel QTabWidget::pane {
+    border: none;
+    margin-top: 12px;
+    padding: 0;
+}
+
+QPushButton#heroButton {
+    background: #1e88e5;
+    color: #ffffff;
+    font-weight: 600;
+    font-size: 16px;
+    padding: 20px 28px;
+    border-radius: 16px;
+    border: none;
+}
+
+QPushButton#heroButton:hover {
+    background: #1565c0;
+}
+
+QPushButton#heroButton:pressed {
+    background: #0d47a1;
 }
 
 QLabel#posTitle,

--- a/app/ui/windows/employee_management_dialog.py
+++ b/app/ui/windows/employee_management_dialog.py
@@ -81,6 +81,7 @@ class EmployeeManagementDialog(QDialog):
 
         self.add_button = QPushButton("Agregar empleado")
         self.add_button.setObjectName("primaryButton")
+        self.add_button.setMinimumHeight(48)
         self.add_button.clicked.connect(self._add_employee)
 
         add_form_layout = QVBoxLayout()
@@ -110,6 +111,7 @@ class EmployeeManagementDialog(QDialog):
 
         self.update_button = QPushButton("Cambiar PIN")
         self.update_button.setObjectName("primaryButton")
+        self.update_button.setMinimumHeight(48)
         self.update_button.clicked.connect(self._change_pin)
 
         update_form_layout = QVBoxLayout()
@@ -123,6 +125,7 @@ class EmployeeManagementDialog(QDialog):
 
         self.delete_button = QPushButton("Eliminar mesero")
         self.delete_button.setObjectName("secondaryButton")
+        self.delete_button.setMinimumHeight(48)
         self.delete_button.clicked.connect(self._delete_employee)
 
         form_container.addWidget(self.delete_button, alignment=Qt.AlignmentFlag.AlignRight)
@@ -140,6 +143,11 @@ class EmployeeManagementDialog(QDialog):
         root_layout.addWidget(card)
         self.resize(900, 540)
 
+        self._load_employees()
+        self._update_actions()
+
+    def showEvent(self, event) -> None:  # type: ignore[override]
+        super().showEvent(event)
         self._load_employees()
         self._update_actions()
 

--- a/app/ui/windows/manager_window.py
+++ b/app/ui/windows/manager_window.py
@@ -40,9 +40,9 @@ class ManagerWindow(QMainWindow):
         self.setMinimumSize(1200, 720)
 
         central = QWidget()
-        central.setObjectName("backgroundWidget")
+        central.setObjectName("AdminPanel")
         main_layout = QVBoxLayout(central)
-        main_layout.setContentsMargins(48, 48, 48, 48)
+        main_layout.setContentsMargins(40, 40, 40, 40)
         main_layout.setSpacing(32)
 
         title = QLabel("Meserito")
@@ -54,7 +54,7 @@ class ManagerWindow(QMainWindow):
         subtitle.setAlignment(Qt.AlignmentFlag.AlignLeft)
 
         actions_card = QWidget()
-        actions_card.setObjectName("contentCard")
+        actions_card.setObjectName("AdminCard")
         actions_layout = QHBoxLayout(actions_card)
         actions_layout.setContentsMargins(32, 32, 32, 32)
         actions_layout.setSpacing(24)
@@ -74,13 +74,14 @@ class ManagerWindow(QMainWindow):
         actions_layout.addStretch(1)
 
         tabs_card = QWidget()
-        tabs_card.setObjectName("contentCard")
+        tabs_card.setObjectName("AdminCard")
         tabs_layout = QVBoxLayout(tabs_card)
         tabs_layout.setContentsMargins(24, 24, 24, 24)
         tabs_layout.setSpacing(16)
 
         self.tabs = QTabWidget()
         self.tabs.setObjectName("managerTabs")
+        self.tabs.setDocumentMode(True)
         tabs_layout.addWidget(self.tabs)
 
         main_layout.addWidget(title)
@@ -100,6 +101,7 @@ class ManagerWindow(QMainWindow):
         fp_layout.addWidget(self.floorplan)
         add_table_btn = QPushButton("Agregar mesa")
         add_table_btn.setObjectName("primaryButton")
+        add_table_btn.setMinimumHeight(48)
         add_table_btn.clicked.connect(self._add_table)
         fp_layout.addWidget(add_table_btn, alignment=Qt.AlignmentFlag.AlignRight)
         self.tabs.addTab(floorplan_tab, "Plano")
@@ -124,10 +126,12 @@ class ManagerWindow(QMainWindow):
 
         add_cat = QPushButton("Agregar categoría")
         add_cat.setObjectName("primaryButton")
+        add_cat.setMinimumHeight(48)
         add_cat.clicked.connect(self._add_category)
 
         toggle_cat = QPushButton("Activar/Desactivar")
         toggle_cat.setObjectName("secondaryButton")
+        toggle_cat.setMinimumHeight(48)
         toggle_cat.clicked.connect(self._toggle_category)
 
         left_layout.addWidget(categories_title)
@@ -149,10 +153,12 @@ class ManagerWindow(QMainWindow):
 
         add_item = QPushButton("Agregar platillo")
         add_item.setObjectName("primaryButton")
+        add_item.setMinimumHeight(48)
         add_item.clicked.connect(self._add_item)
 
         toggle_item = QPushButton("Activar/Desactivar platillo")
         toggle_item.setObjectName("secondaryButton")
+        toggle_item.setMinimumHeight(48)
         toggle_item.clicked.connect(self._toggle_item)
 
         right_layout.addWidget(items_title)
@@ -181,6 +187,7 @@ class ManagerWindow(QMainWindow):
         date_layout.addWidget(self.end_date)
         refresh = QPushButton("Generar")
         refresh.setObjectName("primaryButton")
+        refresh.setMinimumHeight(48)
         refresh.clicked.connect(self._refresh_reports)
         date_layout.addWidget(refresh)
 
@@ -189,6 +196,7 @@ class ManagerWindow(QMainWindow):
 
         export_btn = QPushButton("Exportar CSV")
         export_btn.setObjectName("secondaryButton")
+        export_btn.setMinimumHeight(48)
         export_btn.clicked.connect(self._export_reports)
 
         rep_layout.addWidget(reports_title)
@@ -223,9 +231,9 @@ class ManagerWindow(QMainWindow):
 
     def _apply_shadow(self, widget: QWidget) -> None:
         shadow = QGraphicsDropShadowEffect(self)
-        shadow.setBlurRadius(36)
-        shadow.setOffset(0, 20)
-        shadow.setColor(QColor(30, 136, 229, 70))
+        shadow.setBlurRadius(28)
+        shadow.setOffset(0, 18)
+        shadow.setColor(QColor(23, 111, 200, 40))
         widget.setGraphicsEffect(shadow)
 
     def _add_table(self) -> None:


### PR DESCRIPTION
## Summary
- introduce a reusable `apply_theme` helper that loads a bright palette and larger control defaults across the app
- restyle the manager window with light "AdminPanel" cards, improved spacing, and enlarged admin action buttons
- refresh the stylesheet and employee dialog controls so admin UI elements remain readable and responsive

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68dc97ed55848325a90b41749670256b