### PR TITLE
Persist ticket files and expand report columns

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -13,6 +13,7 @@ from sqlalchemy import (
     Integer,
     String,
     Text,
+    UniqueConstraint,
     func,
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -110,7 +111,12 @@ class Order(Base):
     table: Mapped[Table] = relationship(back_populates="orders", foreign_keys=[table_id])
     waiter: Mapped[Waiter] = relationship(back_populates="orders")
     items: Mapped[List["OrderItem"]] = relationship(back_populates="order", cascade="all, delete-orphan")
-    ticket: Mapped[Optional["Ticket"]] = relationship(back_populates="order", uselist=False)
+    tickets: Mapped[List["Ticket"]] = relationship(
+        back_populates="order", cascade="all, delete-orphan"
+    )
+    payments: Mapped[List["Payment"]] = relationship(
+        back_populates="order", cascade="all, delete-orphan"
+    )
 
     __table_args__ = (
         CheckConstraint("covers >= 1", name="ck_orders_covers_positive"),
@@ -145,13 +151,28 @@ class Ticket(Base):
     __tablename__ = "tickets"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    order_id: Mapped[int] = mapped_column(ForeignKey("orders.id"), nullable=False, unique=True)
-    number: Mapped[int] = mapped_column(Integer, nullable=False, unique=True)
-    payload_json: Mapped[str] = mapped_column(Text, nullable=False)
-    total_cents: Mapped[int] = mapped_column(Integer, nullable=False)
+    order_id: Mapped[int] = mapped_column(ForeignKey("orders.id"), nullable=False)
+    type: Mapped[str] = mapped_column(String(50), default="cliente", nullable=False)
+    file_path: Mapped[str] = mapped_column(String(500), nullable=False)
     created_at: Mapped[datetime] = mapped_column(default=func.now(), nullable=False)
 
-    order: Mapped[Order] = relationship(back_populates="ticket")
+    order: Mapped[Order] = relationship(back_populates="tickets")
+
+    __table_args__ = (
+        UniqueConstraint("order_id", "type", name="uq_tickets_order_type"),
+    )
+
+
+class Payment(Base):
+    __tablename__ = "payments"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    order_id: Mapped[int] = mapped_column(ForeignKey("orders.id"), nullable=False)
+    method: Mapped[str] = mapped_column(String(50), nullable=False)
+    amount_cents: Mapped[int] = mapped_column(Integer, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(default=func.now(), nullable=False)
+
+    order: Mapped[Order] = relationship(back_populates="payments")
 
 
 class Setting(Base):

--- a/app/services/report_service.py
+++ b/app/services/report_service.py
@@ -33,10 +33,13 @@ from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from ..models import (
+    Order,
     OrdersByDay,
     OrdersByTable,
     OrdersByWaiter,
+    Payment,
     Table,
+    Ticket,
     Waiter,
 )
 
@@ -78,4 +81,87 @@ class ReportService:
             writer.writerow(headers)
             for row in rows:
                 writer.writerow(row)
+        return path
+
+    def closed_orders_report(self, start: date, end: date) -> List[dict]:
+        payment_method_sq = (
+            select(Payment.method)
+            .where(Payment.order_id == Order.id)
+            .order_by(Payment.created_at.desc(), Payment.id.desc())
+            .limit(1)
+            .scalar_subquery()
+        )
+        ticket_path_sq = (
+            select(Ticket.file_path)
+            .where(Ticket.order_id == Order.id, Ticket.type == "cliente")
+            .order_by(Ticket.created_at.desc(), Ticket.id.desc())
+            .limit(1)
+            .scalar_subquery()
+        )
+        stmt = (
+            select(
+                Order.closed_at,
+                Table.name,
+                Table.number,
+                Waiter.name,
+                Order.total_cents,
+                payment_method_sq,
+                ticket_path_sq,
+            )
+            .join(Table, Order.table_id == Table.id)
+            .join(Waiter, Order.waiter_id == Waiter.id)
+            .where(
+                Order.status == "closed",
+                Order.closed_at.is_not(None),
+                func.date(Order.closed_at) >= start,
+                func.date(Order.closed_at) <= end,
+            )
+            .order_by(Order.closed_at.desc())
+        )
+        rows = []
+        for (
+            closed_at,
+            table_name,
+            table_number,
+            waiter_name,
+            total_cents,
+            payment_method,
+            ticket_path,
+        ) in self.session.execute(stmt):
+            fecha = closed_at.strftime("%Y-%m-%d %H:%M") if closed_at else ""
+            if table_name:
+                mesa = table_name
+            elif table_number is not None:
+                mesa = f"Mesa {table_number}"
+            else:
+                mesa = ""
+            rows.append(
+                {
+                    "fecha": fecha,
+                    "mesa": mesa,
+                    "mesero": waiter_name or "",
+                    "total_cents": total_cents or 0,
+                    "metodo": payment_method or "",
+                    "ticket": ticket_path or "",
+                }
+            )
+        return rows
+
+    def export_closed_orders_csv(self, rows: Iterable[dict], path: Path) -> Path:
+        headers = ["Fecha", "Mesa", "Mesero", "Total", "Tipo", "Ticket"]
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", newline="", encoding="utf-8") as fh:
+            writer = csv.writer(fh)
+            writer.writerow(headers)
+            for row in rows:
+                writer.writerow(
+                    [
+                        row.get("fecha", ""),
+                        row.get("mesa", ""),
+                        row.get("mesero", ""),
+                        f"{(row.get('total_cents', 0) or 0) / 100:.2f}",
+                        row.get("metodo", ""),
+                        row.get("ticket", ""),
+                    ]
+                )
         return path

--- a/app/services/table_service.py
+++ b/app/services/table_service.py
@@ -8,7 +8,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from ..event_bus import event_bus
-from ..models import Order, OrdersByDay, OrdersByTable, OrdersByWaiter, Table
+from ..models import Order, OrdersByDay, OrdersByTable, OrdersByWaiter, Payment, Table
 from .exceptions import DomainError
 
 
@@ -59,7 +59,12 @@ class TableService:
         event_bus.publish("table_status_changed", {"table_id": table.id, "status": table.status})
         return order
 
-    def close_order(self, table_id: int) -> Order:
+    def close_order(
+        self,
+        table_id: int,
+        payment_method: str | None = None,
+        payment_amount_cents: int | None = None,
+    ) -> Order:
         table = self.get_table(table_id)
         if not table.current_order_id:
             raise DomainError("La mesa no tiene un pedido activo")
@@ -71,6 +76,10 @@ class TableService:
         table.current_order_id = None
         table.status = "free"
         self._update_order_aggregations(order)
+        if payment_method:
+            amount = payment_amount_cents if payment_amount_cents is not None else order.total_cents
+            payment = Payment(order_id=order.id, method=payment_method, amount_cents=amount)
+            self.session.add(payment)
         self.session.flush()
         event_bus.publish("table_status_changed", {"table_id": table.id, "status": table.status})
         return order

--- a/app/services/ticket_service.py
+++ b/app/services/ticket_service.py
@@ -1,14 +1,13 @@
 """Ticket generation service."""
 from __future__ import annotations
 
-import json
 from datetime import datetime
 from pathlib import Path
 from typing import Dict
 
 from reportlab.lib.pagesizes import letter
 from reportlab.pdfgen import canvas
-from sqlalchemy import func, select
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from ..models import Order, Ticket
@@ -47,37 +46,36 @@ class TicketService:
             "total_cents": order.total_cents,
         }
 
-    def generate_pdf(self, order_id: int, output_path: Path) -> Path:
+    def generate_pdf(self, order_id: int, output_path: Path, ticket_type: str = "cliente") -> Path:
         payload = self.build_ticket_payload(order_id)
-        ticket = self._ensure_ticket(order_id, payload)
-        self._render_pdf(ticket, payload, output_path)
+        self._render_pdf(payload, output_path)
+        self._persist_ticket(order_id, ticket_type, output_path)
         return output_path
 
-    def _ensure_ticket(self, order_id: int, payload: Dict) -> Ticket:
-        ticket = self.session.scalar(select(Ticket).where(Ticket.order_id == order_id))
-        if ticket:
-            ticket.payload_json = json.dumps(payload, ensure_ascii=False)
-            ticket.total_cents = payload["total_cents"]
-            self.session.flush()
-            return ticket
-        last_number = self.session.scalar(select(func.max(Ticket.number))) or 0
-        ticket = Ticket(
-            order_id=order_id,
-            number=last_number + 1,
-            payload_json=json.dumps(payload, ensure_ascii=False),
-            total_cents=payload["total_cents"],
+    def _persist_ticket(self, order_id: int, ticket_type: str, output_path: Path) -> Ticket:
+        ticket = self.session.scalar(
+            select(Ticket).where(Ticket.order_id == order_id, Ticket.type == ticket_type)
         )
-        self.session.add(ticket)
+        if ticket:
+            ticket.file_path = str(output_path)
+            ticket.created_at = datetime.utcnow()
+        else:
+            ticket = Ticket(
+                order_id=order_id,
+                type=ticket_type,
+                file_path=str(output_path),
+            )
+            self.session.add(ticket)
         self.session.flush()
         return ticket
 
-    def _render_pdf(self, ticket: Ticket, payload: Dict, output_path: Path) -> None:
+    def _render_pdf(self, payload: Dict, output_path: Path) -> None:
         output_path.parent.mkdir(parents=True, exist_ok=True)
         c = canvas.Canvas(str(output_path), pagesize=letter)
         width, height = letter
         y = height - 50
         c.setFont("Helvetica-Bold", 14)
-        c.drawString(50, y, f"Ticket #{ticket.number}")
+        c.drawString(50, y, f"Ticket pedido #{payload['order_id']}")
         y -= 20
         c.setFont("Helvetica", 11)
         c.drawString(50, y, f"Mesa: {payload['table']}")

--- a/app/ui/windows/manager_window.py
+++ b/app/ui/windows/manager_window.py
@@ -10,6 +10,7 @@ from PyQt6.QtWidgets import (
     QDateEdit,
     QGraphicsDropShadowEffect,
     QHBoxLayout,
+    QHeaderView,
     QLabel,
     QListWidget,
     QListWidgetItem,
@@ -191,8 +192,20 @@ class ManagerWindow(QMainWindow):
         refresh.clicked.connect(self._refresh_reports)
         date_layout.addWidget(refresh)
 
-        self.report_table = QTableWidget(0, 3)
-        self.report_table.setHorizontalHeaderLabels(["Fecha/Mesero/Mesa", "Total", "Tipo"])
+        self.report_table = QTableWidget(0, 6)
+        self.report_table.setHorizontalHeaderLabels([
+            "Fecha",
+            "Mesa",
+            "Mesero",
+            "Total",
+            "Tipo",
+            "Ticket",
+        ])
+        header = self.report_table.horizontalHeader()
+        header.setStretchLastSection(True)
+        header.setDefaultSectionSize(160)
+        header.setSectionResizeMode(QHeaderView.ResizeMode.Interactive)
+        self.report_table.verticalHeader().setDefaultSectionSize(32)
 
         export_btn = QPushButton("Exportar CSV")
         export_btn.setObjectName("secondaryButton")
@@ -205,6 +218,8 @@ class ManagerWindow(QMainWindow):
         rep_layout.addWidget(export_btn, alignment=Qt.AlignmentFlag.AlignRight)
 
         self.tabs.addTab(reports_tab, "Reportes")
+
+        self.report_rows: list[dict] = []
 
         self._load_tables()
         self._load_categories()
@@ -387,20 +402,20 @@ class ManagerWindow(QMainWindow):
             service = ReportService(session)
             start = self.start_date.date().toPyDate()
             end = self.end_date.date().toPyDate()
-            day_rows = service.sales_by_day(start, end)
-            waiter_rows = service.sales_by_waiter(start, end)
-            table_rows = service.sales_by_table(start, end)
+            rows = service.closed_orders_report(start, end)
         finally:
             session.close()
-        data = []
-        data.extend([(str(d), total, "Día") for d, total in day_rows])
-        data.extend([(name, total, "Mesero") for name, total in waiter_rows])
-        data.extend([(str(number), total, "Mesa") for number, total in table_rows])
-        self.report_table.setRowCount(len(data))
-        for row_idx, (label, total, kind) in enumerate(data):
-            self.report_table.setItem(row_idx, 0, QTableWidgetItem(label))
-            self.report_table.setItem(row_idx, 1, QTableWidgetItem(f"${total/100:.2f}"))
-            self.report_table.setItem(row_idx, 2, QTableWidgetItem(kind))
+        self.report_rows = rows
+        self.report_table.setRowCount(len(rows))
+        for row_idx, entry in enumerate(rows):
+            self.report_table.setItem(row_idx, 0, QTableWidgetItem(entry["fecha"]))
+            self.report_table.setItem(row_idx, 1, QTableWidgetItem(entry["mesa"]))
+            self.report_table.setItem(row_idx, 2, QTableWidgetItem(entry["mesero"]))
+            total_item = QTableWidgetItem(f"${entry['total_cents']/100:.2f}")
+            total_item.setTextAlignment(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter)
+            self.report_table.setItem(row_idx, 3, total_item)
+            self.report_table.setItem(row_idx, 4, QTableWidgetItem(entry["metodo"]))
+            self.report_table.setItem(row_idx, 5, QTableWidgetItem(entry["ticket"]))
 
     def _export_reports(self) -> None:
         session = self.session_factory()
@@ -408,9 +423,9 @@ class ManagerWindow(QMainWindow):
             service = ReportService(session)
             start = self.start_date.date().toPyDate()
             end = self.end_date.date().toPyDate()
-            rows = service.sales_by_day(start, end)
-            path = Path("reportes") / "ventas_dia.csv"
-            service.export_to_csv(rows, ["Fecha", "Total"], path)
+            rows = service.closed_orders_report(start, end)
+            path = Path("reportes") / "historial_ordenes.csv"
+            service.export_closed_orders_csv(rows, path)
             QMessageBox.information(self, "Meserito", f"Reporte exportado a {path}")
         except Exception as exc:
             session.rollback()

--- a/app/ui/windows/waiter_window.py
+++ b/app/ui/windows/waiter_window.py
@@ -422,10 +422,14 @@ class WaiterWindow(QMainWindow):
             order_service = OrderService(session)
             table_service = TableService(session)
             order = order_service.compute_totals(self.current_order_id)
-            closed_order = table_service.close_order(self.selected_table_id)
+            closed_order = table_service.close_order(
+                self.selected_table_id,
+                payment_method="efectivo",
+                payment_amount_cents=order.total_cents,
+            )
             ticket_service = TicketService(session)
             output = Path("tickets") / f"ticket_{order.id}.pdf"
-            ticket_service.generate_pdf(closed_order.id, output)
+            ticket_service.generate_pdf(closed_order.id, output, ticket_type="cliente")
             session.commit()
             QMessageBox.information(
                 self,


### PR DESCRIPTION
## Summary
- add ticket metadata and payment records when closing orders so PDF paths are stored
- expose a detailed closed-orders report with separate columns and CSV export
- update the manager reports UI to display the new data without truncation

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc9c4568fc832588dea8145ca881b7