### PR TITLE
Remove unused waiter sidebar and add dark theme

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -15,20 +15,25 @@ from .ui.windows.login_window import LoginWindow
 
 
 def apply_theme(app: QApplication) -> None:
-    """Apply a bright, legible theme with comfortable control sizes."""
+    """Apply the requested dark theme and consistent control metrics."""
     palette = QPalette()
-    palette.setColor(QPalette.ColorRole.Window, QColor("#f5f8ff"))
-    palette.setColor(QPalette.ColorRole.WindowText, QColor("#0b1e3f"))
-    palette.setColor(QPalette.ColorRole.Base, QColor("#ffffff"))
-    palette.setColor(QPalette.ColorRole.AlternateBase, QColor("#f0f4ff"))
-    palette.setColor(QPalette.ColorRole.ToolTipBase, QColor("#ffffff"))
-    palette.setColor(QPalette.ColorRole.ToolTipText, QColor("#0b1e3f"))
-    palette.setColor(QPalette.ColorRole.Text, QColor("#0b1e3f"))
-    palette.setColor(QPalette.ColorRole.Button, QColor("#ffffff"))
-    palette.setColor(QPalette.ColorRole.ButtonText, QColor("#0b1e3f"))
-    palette.setColor(QPalette.ColorRole.Highlight, QColor("#1e88e5"))
+    background = QColor("#121212")
+    surface = QColor("#1f1f1f")
+    text = QColor("#ececec")
+    accent = QColor("#1e88e5")
+    # Paleta oscura para mejorar contraste en toda la app.
+    palette.setColor(QPalette.ColorRole.Window, background)
+    palette.setColor(QPalette.ColorRole.WindowText, text)
+    palette.setColor(QPalette.ColorRole.Base, surface)
+    palette.setColor(QPalette.ColorRole.AlternateBase, QColor("#181818"))
+    palette.setColor(QPalette.ColorRole.ToolTipBase, surface)
+    palette.setColor(QPalette.ColorRole.ToolTipText, text)
+    palette.setColor(QPalette.ColorRole.Text, text)
+    palette.setColor(QPalette.ColorRole.Button, surface)
+    palette.setColor(QPalette.ColorRole.ButtonText, text)
+    palette.setColor(QPalette.ColorRole.Highlight, accent)
     palette.setColor(QPalette.ColorRole.HighlightedText, QColor("#ffffff"))
-    palette.setColor(QPalette.ColorRole.PlaceholderText, QColor(11, 30, 63, 120))
+    palette.setColor(QPalette.ColorRole.PlaceholderText, QColor(236, 236, 236, 110))
     app.setPalette(palette)
 
     base_font = QFont("Poppins", 11)
@@ -36,43 +41,106 @@ def apply_theme(app: QApplication) -> None:
     app.setFont(base_font)
 
     base_stylesheet = """
+    * {
+        color: #ECECEC;
+        background-color: transparent;
+    }
     QWidget {
         font-size: 15px;
+        background-color: #121212;
+    }
+    QFrame#menuArea,
+    QFrame#orderPanel,
+    QWidget#dialogCard,
+    QWidget#loginCard,
+    QWidget#AdminCard,
+    QWidget#formCard {
+        background-color: #1f1f1f;
+        border-radius: 18px;
+        border: 1px solid #2c2c2c;
     }
     QPushButton,
     QToolButton {
-        min-height: 44px;
-        padding: 12px 20px;
-        border-radius: 14px;
+        min-height: 38px;
+        padding: 8px 16px;
+        border-radius: 8px;
         font-size: 15px;
+        background-color: #1e88e5;
+        color: #ECECEC;
+        border: 1px solid #1e88e5;
     }
     QPushButton:disabled,
     QToolButton:disabled {
-        opacity: 0.6;
+        background-color: #2c2c2c;
+        border-color: #2c2c2c;
+        color: rgba(236, 236, 236, 120);
+    }
+    QPushButton:hover,
+    QToolButton:hover {
+        background-color: #42a5f5;
+        border-color: #42a5f5;
+    }
+    QPushButton:pressed,
+    QToolButton:pressed {
+        background-color: #1565c0;
+        border-color: #1565c0;
+    }
+    QLineEdit,
+    QComboBox,
+    QSpinBox,
+    QTextEdit,
+    QPlainTextEdit {
+        min-height: 34px;
+        padding: 6px 12px;
+        border-radius: 8px;
+        background-color: #181818;
+        border: 1px solid #2c2c2c;
+        color: #ECECEC;
+        selection-background-color: #1e88e5;
     }
     QTabBar::tab {
-        min-height: 40px;
-        padding: 10px 18px;
-        font-size: 15px;
-        border-radius: 12px;
+        min-height: 38px;
+        padding: 8px 16px;
+        border-radius: 8px;
         margin: 0 4px;
+        background-color: #1f1f1f;
+        color: #ECECEC;
     }
     QTabBar::tab:selected {
-        background: #ffffff;
-        color: #1565c0;
+        background-color: #263238;
+        color: #ECECEC;
     }
     QTabWidget::pane {
-        border: 1px solid #d7e3ff;
-        border-radius: 16px;
-        background: #ffffff;
+        border: 1px solid #2c2c2c;
+        border-radius: 12px;
         padding: 8px;
+    }
+    QHeaderView::section {
+        background-color: #1f1f1f;
+        color: #ECECEC;
+        padding: 8px;
+        border: none;
+        border-bottom: 1px solid #2c2c2c;
+    }
+    QTableView,
+    QTableWidget {
+        background-color: #181818;
+        gridline-color: #2c2c2c;
+        alternate-background-color: #1f1f1f;
+    }
+    QListWidget,
+    QTreeWidget,
+    QScrollArea {
+        background-color: transparent;
     }
     """
 
     stylesheet_path = Path(__file__).resolve().parent / "styles.qss"
-    styles = [base_stylesheet]
+    styles = []
     if stylesheet_path.exists():
         styles.append(stylesheet_path.read_text(encoding="utf-8"))
+    # Añadimos la hoja de estilo oscura al final para asegurar prioridad.
+    styles.append(base_stylesheet)
     app.setStyleSheet("\n".join(styles))
 
 

--- a/app/ui/windows/manager_window.py
+++ b/app/ui/windows/manager_window.py
@@ -203,8 +203,8 @@ class ManagerWindow(QMainWindow):
         ])
         header = self.report_table.horizontalHeader()
         header.setStretchLastSection(True)
-        header.setDefaultSectionSize(160)
-        header.setSectionResizeMode(QHeaderView.ResizeMode.Interactive)
+        header.setSectionResizeMode(QHeaderView.ResizeMode.ResizeToContents)
+        # Ajuste para que el contenido no se corte en los listados.
         self.report_table.verticalHeader().setDefaultSectionSize(32)
 
         export_btn = QPushButton("Exportar CSV")

--- a/app/ui/windows/waiter_window.py
+++ b/app/ui/windows/waiter_window.py
@@ -5,7 +5,7 @@ from functools import partial
 from pathlib import Path
 from typing import Dict, List, Optional
 
-from PyQt6.QtCore import Qt, QSize, pyqtSignal
+from PyQt6.QtCore import Qt, pyqtSignal
 from PyQt6.QtGui import QColor
 from PyQt6.QtWidgets import (
     QComboBox,
@@ -20,7 +20,6 @@ from PyQt6.QtWidgets import (
     QPushButton,
     QScrollArea,
     QSpinBox,
-    QStyle,
     QVBoxLayout,
     QWidget,
     QGraphicsDropShadowEffect,
@@ -155,8 +154,18 @@ class WaiterWindow(QMainWindow):
         self.waiter = waiter
         self.session_factory = session_factory
         self.current_waiter_id = waiter.id
-        self.current_waiter_name = waiter.name
-        self.setWindowTitle(f"Meserito — Mesero {waiter.name}")
+        display_name = waiter.name or getattr(waiter, "username", "")
+        if not display_name:
+            display_name = getattr(waiter, "pin", "")
+        self.waiter_display_name = display_name
+        # Guardar el rol para aplicar reglas de visibilidad sin referenciar tarjetas inútiles.
+        self.waiter_role = getattr(
+            waiter,
+            "role",
+            "admin" if getattr(waiter, "is_manager", False) else "waiter",
+        )
+        # Mostrar el nombre del mesero en el título como pidió el product owner.
+        self.setWindowTitle(f"Meserito — Mesero: {self.waiter_display_name}")
         self.selected_table_id: Optional[int] = None
         self.current_order_id: Optional[int] = None
         self.tables_by_id: Dict[int, Table] = {}
@@ -182,55 +191,18 @@ class WaiterWindow(QMainWindow):
         main_layout.setContentsMargins(24, 24, 24, 24)
         main_layout.setSpacing(24)
 
-        # Sidebar navigation
-        self.sidebar = QFrame()
-        self.sidebar.setObjectName("sidebar")
-        self.sidebar.setFixedWidth(120)
-        sidebar_layout = QVBoxLayout(self.sidebar)
-        sidebar_layout.setContentsMargins(12, 24, 12, 24)
-        sidebar_layout.setSpacing(12)
-
-        self.session_label = QLabel(f"Sesión: {self.current_waiter_name}")
-        self.session_label.setObjectName("sessionLabel")
-        self.session_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.session_label.setWordWrap(True)
-
-        self.role_label = QLabel("Mesero")
-        self.role_label.setObjectName("sessionRoleLabel")
-        self.role_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-
-        sidebar_layout.addWidget(self.session_label)
-        sidebar_layout.addWidget(self.role_label)
-        sidebar_layout.addSpacing(12)
-
-        style = self.style()
-        nav_items = [
-            ("Menú", QStyle.StandardPixmap.SP_FileDialogContentsView),
-            ("Órdenes", QStyle.StandardPixmap.SP_FileDialogDetailedView),
-            ("Historial", QStyle.StandardPixmap.SP_DialogOpenButton),
-            ("Reportes", QStyle.StandardPixmap.SP_ComputerIcon),
-            ("Configuración", QStyle.StandardPixmap.SP_FileDialogListView),
-        ]
-        self.sidebar_buttons: List[QPushButton] = []
-        for index, (text, icon_enum) in enumerate(nav_items):
-            button = QPushButton(text)
-            button.setObjectName("sidebarButton")
-            button.setFlat(True)
-            button.setCursor(Qt.CursorShape.PointingHandCursor)
-            button.setIcon(style.standardIcon(icon_enum))
-            button.setIconSize(QSize(24, 24))
-            if index == 0:
-                button.setProperty("active", True)
-            sidebar_layout.addWidget(button)
-            self.sidebar_buttons.append(button)
-        sidebar_layout.addStretch(1)
-
-        # Central menu area
+        # Áreas principales sin la tarjeta lateral inútil.
         self.menu_area = QFrame()
         self.menu_area.setObjectName("menuArea")
         menu_layout = QVBoxLayout(self.menu_area)
         menu_layout.setContentsMargins(24, 24, 24, 24)
         menu_layout.setSpacing(18)
+
+        # Badge discreto para mostrar quién está logueado sin usar la tarjeta eliminada.
+        role_label = "Administrador" if self.waiter_role == "admin" else "Mesero"
+        session_badge = QLabel(f"{role_label}: {self.waiter_display_name}")
+        session_badge.setObjectName("sessionLabel")
+        session_badge.setAlignment(Qt.AlignmentFlag.AlignRight)
 
         title = QLabel("Menú de productos")
         title.setObjectName("posTitle")
@@ -263,6 +235,7 @@ class WaiterWindow(QMainWindow):
             self.products_layout.setColumnStretch(column, 1)
         self.products_scroll.setWidget(self.products_widget)
 
+        menu_layout.addWidget(session_badge, 0, alignment=Qt.AlignmentFlag.AlignRight)
         menu_layout.addWidget(title)
         menu_layout.addWidget(subtitle)
         menu_layout.addWidget(self.category_scroll)
@@ -356,9 +329,8 @@ class WaiterWindow(QMainWindow):
         order_layout.addWidget(self.print_button)
         order_layout.addWidget(self.finalize_button)
 
-        main_layout.addWidget(self.sidebar, 0)
-        main_layout.addWidget(self.menu_area, 1)
-        main_layout.addWidget(self.order_panel, 0)
+        main_layout.addWidget(self.menu_area, 3)
+        main_layout.addWidget(self.order_panel, 2)
 
         self.setCentralWidget(central)
         central.setStyleSheet(central.styleSheet() + "\nQScrollBar:horizontal { height: 0px; }")


### PR DESCRIPTION
## Summary
- remove the unused waiter sidebar card and surface the logged in waiter in a compact badge
- update the application palette and stylesheet to the requested dark theme with improved control metrics
- resize manager report headers so table text stays readable

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68dca336f43c8325804eb31d96e614a5