### PR TITLE
Implement high-DPI theme and payment-aware ticketing

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -5,7 +5,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Generator
 
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 from sqlalchemy.orm import DeclarativeBase, sessionmaker
 
 
@@ -42,3 +42,24 @@ def session_scope() -> Generator:
         raise
     finally:
         session.close()
+
+
+def run_migrations() -> None:
+    """Apply lightweight migrations required for new ticket fields."""
+
+    with engine.begin() as connection:
+        ticket_columns = {
+            row[1] for row in connection.execute(text("PRAGMA table_info('tickets')"))
+        }
+        if "payment_type" not in ticket_columns:
+            connection.execute(text("ALTER TABLE tickets ADD COLUMN payment_type TEXT"))
+        if "card_last4" not in ticket_columns:
+            connection.execute(text("ALTER TABLE tickets ADD COLUMN card_last4 TEXT"))
+
+        order_columns = {
+            row[1] for row in connection.execute(text("PRAGMA table_info('orders')"))
+        }
+        if "payment_type" not in order_columns:
+            connection.execute(text("ALTER TABLE orders ADD COLUMN payment_type TEXT"))
+        if "card_last4" not in order_columns:
+            connection.execute(text("ALTER TABLE orders ADD COLUMN card_last4 TEXT"))

--- a/app/main.py
+++ b/app/main.py
@@ -4,144 +4,79 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-from PyQt6.QtGui import QColor, QFont, QPalette
-from PyQt6.QtWidgets import QApplication
+from PyQt6.QtCore import QEvent, QObject, Qt
+from PyQt6.QtGui import QFont, QGuiApplication
+from PyQt6.QtWidgets import QApplication, QHeaderView, QTableView, QTableWidget
 from sqlalchemy import select
 
-from .db import Base, SessionLocal, engine
+from .db import Base, SessionLocal, engine, run_migrations
 from .models import Category, MenuItem, Table, Waiter
 from .services import AuthService
 from .ui.windows.login_window import LoginWindow
 
 
+class _HeaderAutoResizer(QObject):
+    """Ensure table headers resize contents for better readability."""
+
+    def eventFilter(self, watched: QObject, event: QEvent) -> bool:  # pragma: no cover - GUI hook
+        if event.type() == QEvent.Type.Show and isinstance(watched, (QTableView, QTableWidget)):
+            header = watched.horizontalHeader()
+            if header is not None:
+                header.setSectionResizeMode(QHeaderView.ResizeMode.ResizeToContents)
+                header.setStretchLastSection(True)
+        return super().eventFilter(watched, event)
+
+
 def apply_theme(app: QApplication) -> None:
-    """Apply the requested dark theme and consistent control metrics."""
-    palette = QPalette()
-    background = QColor("#121212")
-    surface = QColor("#1f1f1f")
-    text = QColor("#ececec")
-    accent = QColor("#1e88e5")
-    # Paleta oscura para mejorar contraste en toda la app.
-    palette.setColor(QPalette.ColorRole.Window, background)
-    palette.setColor(QPalette.ColorRole.WindowText, text)
-    palette.setColor(QPalette.ColorRole.Base, surface)
-    palette.setColor(QPalette.ColorRole.AlternateBase, QColor("#181818"))
-    palette.setColor(QPalette.ColorRole.ToolTipBase, surface)
-    palette.setColor(QPalette.ColorRole.ToolTipText, text)
-    palette.setColor(QPalette.ColorRole.Text, text)
-    palette.setColor(QPalette.ColorRole.Button, surface)
-    palette.setColor(QPalette.ColorRole.ButtonText, text)
-    palette.setColor(QPalette.ColorRole.Highlight, accent)
-    palette.setColor(QPalette.ColorRole.HighlightedText, QColor("#ffffff"))
-    palette.setColor(QPalette.ColorRole.PlaceholderText, QColor(236, 236, 236, 110))
-    app.setPalette(palette)
+    """Apply high-contrast Meserito dark theme and control metrics."""
 
     base_font = QFont("Poppins", 11)
+    base_font.setHintingPreference(QFont.HintingPreference.PreferFullHinting)
     base_font.setStyleStrategy(QFont.StyleStrategy.PreferAntialias)
     app.setFont(base_font)
 
-    base_stylesheet = """
-    * {
-        color: #ECECEC;
-        background-color: transparent;
-    }
-    QWidget {
-        font-size: 15px;
-        background-color: #121212;
-    }
-    QFrame#menuArea,
-    QFrame#orderPanel,
-    QWidget#dialogCard,
-    QWidget#loginCard,
-    QWidget#AdminCard,
-    QWidget#formCard {
-        background-color: #1f1f1f;
-        border-radius: 18px;
-        border: 1px solid #2c2c2c;
-    }
-    QPushButton,
-    QToolButton {
-        min-height: 38px;
-        padding: 8px 16px;
-        border-radius: 8px;
-        font-size: 15px;
-        background-color: #1e88e5;
-        color: #ECECEC;
-        border: 1px solid #1e88e5;
-    }
-    QPushButton:disabled,
-    QToolButton:disabled {
-        background-color: #2c2c2c;
-        border-color: #2c2c2c;
-        color: rgba(236, 236, 236, 120);
-    }
-    QPushButton:hover,
-    QToolButton:hover {
-        background-color: #42a5f5;
-        border-color: #42a5f5;
-    }
-    QPushButton:pressed,
-    QToolButton:pressed {
-        background-color: #1565c0;
-        border-color: #1565c0;
-    }
-    QLineEdit,
-    QComboBox,
-    QSpinBox,
-    QTextEdit,
-    QPlainTextEdit {
-        min-height: 34px;
-        padding: 6px 12px;
-        border-radius: 8px;
-        background-color: #181818;
-        border: 1px solid #2c2c2c;
-        color: #ECECEC;
-        selection-background-color: #1e88e5;
-    }
-    QTabBar::tab {
-        min-height: 38px;
-        padding: 8px 16px;
-        border-radius: 8px;
-        margin: 0 4px;
-        background-color: #1f1f1f;
-        color: #ECECEC;
-    }
-    QTabBar::tab:selected {
-        background-color: #263238;
-        color: #ECECEC;
-    }
-    QTabWidget::pane {
-        border: 1px solid #2c2c2c;
-        border-radius: 12px;
-        padding: 8px;
-    }
-    QHeaderView::section {
-        background-color: #1f1f1f;
-        color: #ECECEC;
-        padding: 8px;
-        border: none;
-        border-bottom: 1px solid #2c2c2c;
-    }
-    QTableView,
-    QTableWidget {
-        background-color: #181818;
-        gridline-color: #2c2c2c;
-        alternate-background-color: #1f1f1f;
-    }
-    QListWidget,
-    QTreeWidget,
-    QScrollArea {
-        background-color: transparent;
-    }
-    """
-
     stylesheet_path = Path(__file__).resolve().parent / "styles.qss"
-    styles = []
+    styles: list[str] = []
     if stylesheet_path.exists():
         styles.append(stylesheet_path.read_text(encoding="utf-8"))
-    # Añadimos la hoja de estilo oscura al final para asegurar prioridad.
+
+    base_stylesheet = """
+    * { color: #E9EEF5; }
+    QMainWindow, QWidget { background: #0F1216; }
+    QGroupBox, QFrame, QTabWidget::pane { background: #161A20; border: 1px solid #1C222B; border-radius: 12px; }
+    QPushButton { background: #1E66FF; border: none; border-radius: 12px; min-height: 40px; padding: 10px 16px; font-weight: 600; }
+    QPushButton:hover { background: #2A70FF; }
+    QPushButton:pressed { background: #1556D0; }
+    QPushButton:disabled { background: #2A3550; color: #9BA7B4; }
+    QLineEdit, QComboBox, QTextEdit, QPlainTextEdit, QSpinBox { background: #0F1216; border: 1px solid #273140; border-radius: 10px; min-height: 36px; padding: 6px 10px; }
+    QHeaderView::section { background: #1C222B; color: #E9EEF5; padding: 6px; border: none; }
+    QTabBar::tab { background: #161A20; padding: 8px 14px; margin-right: 6px; border-radius: 10px; }
+    QTabBar::tab:selected { background: #1C222B; }
+    QLabel[heading="true"] { font-size: 22px; font-weight: 800; color: #E9EEF5; }
+    .QSuccess { background: #1DB954; }
+    .QWarn { background: #FF9800; }
+    .QDanger { background: #EF4444; }
+    QListView, QTreeView, QTableView, QTableWidget { background: #0F1216; alternate-background-color: #161A20; gridline-color: #1C222B; }
+    QScrollBar:vertical { background: #161A20; width: 12px; margin: 2px; }
+    QScrollBar::handle:vertical { background: #273140; border-radius: 6px; }
+    """
     styles.append(base_stylesheet)
     app.setStyleSheet("\n".join(styles))
+
+    resizer = _HeaderAutoResizer(app)
+    app.installEventFilter(resizer)
+    app._meserito_header_resizer = resizer  # type: ignore[attr-defined]
+    # TODO: Persist custom table sizing preferences per view.
+
+
+def _enable_high_dpi() -> None:
+    """Turn on the High-DPI flags to avoid blurred UI on modern displays."""
+
+    QGuiApplication.setHighDpiScaleFactorRoundingPolicy(
+        Qt.HighDpiScaleFactorRoundingPolicy.PassThrough
+    )
+    QApplication.setAttribute(Qt.ApplicationAttribute.AA_EnableHighDpiScaling, True)
+    QApplication.setAttribute(Qt.ApplicationAttribute.AA_UseHighDpiPixmaps, True)
 
 
 def seed_database() -> None:
@@ -197,7 +132,10 @@ def seed_database() -> None:
 
 def main() -> int:
     Base.metadata.create_all(bind=engine)
+    run_migrations()
     seed_database()
+
+    _enable_high_dpi()
 
     app = QApplication(sys.argv)
     apply_theme(app)

--- a/app/models.py
+++ b/app/models.py
@@ -107,6 +107,8 @@ class Order(Base):
     subtotal_cents: Mapped[int] = mapped_column(Integer, default=0)
     tax_cents: Mapped[int] = mapped_column(Integer, default=0)
     total_cents: Mapped[int] = mapped_column(Integer, default=0)
+    payment_type: Mapped[Optional[str]] = mapped_column(String(50))
+    card_last4: Mapped[Optional[str]] = mapped_column(String(4))
 
     table: Mapped[Table] = relationship(back_populates="orders", foreign_keys=[table_id])
     waiter: Mapped[Waiter] = relationship(back_populates="orders")
@@ -155,6 +157,8 @@ class Ticket(Base):
     type: Mapped[str] = mapped_column(String(50), default="cliente", nullable=False)
     file_path: Mapped[str] = mapped_column(String(500), nullable=False)
     created_at: Mapped[datetime] = mapped_column(default=func.now(), nullable=False)
+    payment_type: Mapped[Optional[str]] = mapped_column(String(50))
+    card_last4: Mapped[Optional[str]] = mapped_column(String(4))
 
     order: Mapped[Order] = relationship(back_populates="tickets")
 

--- a/app/printing/ticket.py
+++ b/app/printing/ticket.py
@@ -1,14 +1,190 @@
-"""Convenience helpers for ticket printing."""
+"""Ticket rendering and printing helpers for Meserito."""
 from __future__ import annotations
 
+from datetime import datetime
 from pathlib import Path
+from typing import Iterable, Mapping, Optional
 
-from sqlalchemy.orm import Session
+from PyQt6.QtCore import QMarginsF, QSizeF
+from PyQt6.QtGui import QFont, QPageLayout, QPageSize, QTextDocument
+from PyQt6.QtPrintSupport import QPrinter, QPrinterInfo
 
-from ..services.ticket_service import TicketService
+
+def ensure_ticket_output_path(
+    timestamp: datetime, order_id: int, *, ensure_closed: bool = True
+) -> Path:
+    """Create the ticket folder structure and return the target PDF path."""
+
+    safe_timestamp = timestamp or datetime.utcnow()
+    date_folder = safe_timestamp.strftime("%Y-%m-%d")
+    output_dir = Path("tickets") / date_folder
+    output_dir.mkdir(parents=True, exist_ok=True)
+    if ensure_closed:
+        filename = f"ticket_{order_id}.pdf"
+    else:
+        filename = f"ticket_{order_id}_preview.pdf"
+    return output_dir / filename
 
 
-def print_ticket(session: Session, order_id: int, output_path: Path) -> Path:
-    """Generate a ticket PDF for the given order using the shared ticket service."""
-    service = TicketService(session)
-    return service.generate_pdf(order_id, output_path)
+def render_ticket_html(
+    *,
+    restaurant_name: str,
+    receipt_title: str,
+    mesa: Optional[str],
+    mesero: Optional[str],
+    items: Iterable[Mapping[str, object]],
+    subtotal_cents: int,
+    discount_cents: int,
+    tax_cents: int,
+    total_cents: int,
+    payment_type: Optional[str],
+    card_last4: Optional[str],
+    created_at: datetime,
+    message: str = "¡Gracias por su visita!",
+) -> str:
+    """Generate a rich HTML representation for an 80mm ticket."""
+
+    created_display = created_at.strftime("%d/%m/%Y %H:%M")
+    mesa_text = mesa or "-"
+    mesero_text = mesero or "-"
+    payment_display = (payment_type or "Pendiente").title()
+    if payment_display.lower() == "tarjeta" and card_last4:
+        payment_display = f"Tarjeta (**** {card_last4})"
+
+    def _format_amount(cents: int) -> str:
+        return f"${cents / 100:.2f}"
+
+    lines: list[str] = []
+    for item in items:
+        qty = int(item.get("qty", 0))
+        name = str(item.get("name", ""))
+        total_cents = int(item.get("total_cents", 0))
+        lines.append(
+            """
+            <tr>
+                <td class="qty">{qty}x</td>
+                <td class="desc">{name}</td>
+                <td class="amount">{amount}</td>
+            </tr>
+            """.format(qty=qty, name=name, amount=_format_amount(total_cents))
+        )
+
+    items_html = "\n".join(lines) or "<tr><td colspan='3'>Sin productos</td></tr>"
+
+    html = f"""
+    <html>
+      <head>
+        <meta charset="utf-8" />
+        <style>
+          body {{ font-family: 'DejaVu Sans Mono', monospace; font-size: 10pt; margin: 0; color: #0F1216; }}
+          .ticket {{ width: 100%; padding: 4px 0; color: #0F1216; }}
+          h1 {{ font-size: 16pt; margin: 0; text-align: center; text-transform: uppercase; }}
+          h3 {{ font-size: 12pt; margin: 4px 0 12px; text-align: center; letter-spacing: 1px; }}
+          .meta {{ font-size: 9pt; margin-bottom: 10px; }}
+          .meta div {{ margin-bottom: 2px; }}
+          table {{ width: 100%; border-collapse: collapse; font-size: 9pt; }}
+          th, td {{ padding: 2px 0; text-align: left; }}
+          .qty {{ width: 18%; }}
+          .desc {{ width: 52%; }}
+          .amount {{ width: 30%; text-align: right; }}
+          .totals {{ margin-top: 8px; border-top: 1px dashed #161A20; padding-top: 6px; }}
+          .totals div {{ display: flex; justify-content: space-between; margin-bottom: 2px; }}
+          .totals .grand {{ font-size: 12pt; font-weight: 700; margin-top: 6px; }}
+          .footer {{ margin-top: 12px; text-align: center; font-size: 9pt; }}
+        </style>
+      </head>
+      <body>
+        <div class="ticket">
+          <h1>{restaurant_name}</h1>
+          <h3>{receipt_title}</h3>
+          <div class="meta">
+            <div><strong>Mesa:</strong> {mesa_text}</div>
+            <div><strong>Mesero:</strong> {mesero_text}</div>
+            <div><strong>Fecha:</strong> {created_display}</div>
+          </div>
+          <table>
+            <thead>
+              <tr>
+                <th class="qty">Cant</th>
+                <th class="desc">Descripción</th>
+                <th class="amount">Importe</th>
+              </tr>
+            </thead>
+            <tbody>
+              {items_html}
+            </tbody>
+          </table>
+          <div class="totals">
+            <div><span>Subtotal</span><span>{_format_amount(subtotal_cents)}</span></div>
+            <div><span>Descuento</span><span>{_format_amount(discount_cents)}</span></div>
+            <div><span>Impuestos</span><span>{_format_amount(tax_cents)}</span></div>
+            <div class="grand"><span>Total</span><span>{_format_amount(total_cents)}</span></div>
+          </div>
+          <div class="meta" style="margin-top: 8px;">
+            <div><strong>Forma de pago:</strong> {payment_display}</div>
+          </div>
+          <div class="footer">{message}</div>
+        </div>
+      </body>
+    </html>
+    """
+    return html
+
+
+def print_ticket_document(
+    payload: Mapping[str, object],
+    output_path: Path,
+    *,
+    printer_name: Optional[str] = None,
+) -> Optional[Path]:
+    """Render the given ticket payload and print it on an 80mm layout."""
+
+    html = render_ticket_html(
+        restaurant_name=str(payload.get("restaurant_name", "Meserito")).upper(),
+        receipt_title=str(payload.get("receipt_title", "RECIBO DE COBRO")).upper(),
+        mesa=str(payload.get("mesa", "")) if payload.get("mesa") is not None else None,
+        mesero=str(payload.get("mesero", "")) if payload.get("mesero") else None,
+        items=payload.get("items", []) or [],
+        subtotal_cents=int(payload.get("subtotal_cents", 0)),
+        discount_cents=int(payload.get("discount_cents", 0)),
+        tax_cents=int(payload.get("tax_cents", 0)),
+        total_cents=int(payload.get("total_cents", 0)),
+        payment_type=payload.get("payment_type"),
+        card_last4=payload.get("card_last4"),
+        created_at=payload.get("created_at") or datetime.utcnow(),
+    )
+
+    printer = QPrinter(QPrinter.PrinterMode.HighResolution)
+    page_size = QPageSize(QSizeF(80.0, 2000.0), QPageSize.Unit.Millimeter)
+    printer.setPageSize(page_size)
+    printer.setPageMargins(QMarginsF(3, 3, 3, 3), QPageLayout.Unit.Millimeter)
+    printer.setColorMode(QPrinter.ColorMode.GrayScale)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if printer_name:
+        printer.setPrinterName(printer_name)
+    else:
+        default_printer = QPrinterInfo.defaultPrinter()
+        if default_printer.isNull():
+            printer.setOutputFormat(QPrinter.OutputFormat.PdfFormat)
+            printer.setOutputFileName(str(output_path))
+        else:
+            printer.setPrinterName(default_printer.printerName())
+
+    if printer.outputFormat() == QPrinter.OutputFormat.NativeFormat and not printer.isValid():
+        printer.setOutputFormat(QPrinter.OutputFormat.PdfFormat)
+        printer.setOutputFileName(str(output_path))
+    elif printer.outputFormat() == QPrinter.OutputFormat.PdfFormat:
+        printer.setOutputFileName(str(output_path))
+
+    document = QTextDocument()
+    document.setDefaultFont(QFont("DejaVu Sans Mono", 10))
+    document.setHtml(html)
+    document.setPageSize(page_size.sizePoints())
+    # TODO: Incorporar impresión directa a múltiples impresoras configurables.
+    document.print_(printer)
+
+    if printer.outputFormat() == QPrinter.OutputFormat.PdfFormat:
+        return Path(printer.outputFileName()) if printer.outputFileName() else output_path
+    return None

--- a/app/services/table_service.py
+++ b/app/services/table_service.py
@@ -64,6 +64,9 @@ class TableService:
         table_id: int,
         payment_method: str | None = None,
         payment_amount_cents: int | None = None,
+        *,
+        payment_type: str | None = None,
+        card_last4: str | None = None,
     ) -> Order:
         table = self.get_table(table_id)
         if not table.current_order_id:
@@ -76,9 +79,21 @@ class TableService:
         table.current_order_id = None
         table.status = "free"
         self._update_order_aggregations(order)
-        if payment_method:
+        if payment_type:
+            order.payment_type = payment_type
+        elif payment_method:
+            order.payment_type = payment_method
+        else:
+            order.payment_type = None
+        if card_last4:
+            order.card_last4 = card_last4
+        else:
+            order.card_last4 = None
+
+        normalized_method = payment_method or (payment_type.lower() if payment_type else None)
+        if normalized_method:
             amount = payment_amount_cents if payment_amount_cents is not None else order.total_cents
-            payment = Payment(order_id=order.id, method=payment_method, amount_cents=amount)
+            payment = Payment(order_id=order.id, method=normalized_method, amount_cents=amount)
             self.session.add(payment)
         self.session.flush()
         event_bus.publish("table_status_changed", {"table_id": table.id, "status": table.status})

--- a/app/services/ticket_service.py
+++ b/app/services/ticket_service.py
@@ -5,13 +5,27 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict
 
-from reportlab.lib.pagesizes import letter
-from reportlab.pdfgen import canvas
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from ..models import Order, Ticket
+from ..printing.ticket import print_ticket_document
 from .exceptions import DomainError
+
+
+def _resolve_datetime(payload: Dict) -> datetime:
+    """Return a datetime object from the payload, falling back to utcnow."""
+
+    closed_dt = payload.get("closed_at_dt")
+    if isinstance(closed_dt, datetime):
+        return closed_dt
+    closed_at = payload.get("closed_at")
+    if isinstance(closed_at, str):
+        try:
+            return datetime.fromisoformat(closed_at)
+        except ValueError:  # pragma: no cover - defensive
+            pass
+    return datetime.utcnow()
 
 
 class TicketService:
@@ -35,70 +49,61 @@ class TicketService:
         ]
         return {
             "order_id": order.id,
-            "table": order.table.number,
-            "waiter": order.waiter.name,
+            "table": order.table.number if order.table else None,
+            "waiter": order.waiter.name if order.waiter else None,
             "covers": order.covers,
             "opened_at": order.opened_at.isoformat(),
             "closed_at": order.closed_at.isoformat() if order.closed_at else None,
+            "closed_at_dt": order.closed_at,
             "items": items,
             "subtotal_cents": order.subtotal_cents,
             "tax_cents": order.tax_cents,
             "total_cents": order.total_cents,
+            "discount_cents": getattr(order, "discount_cents", 0),
+            "payment_type": order.payment_type,
+            "card_last4": order.card_last4,
         }
 
     def generate_pdf(self, order_id: int, output_path: Path, ticket_type: str = "cliente") -> Path:
         payload = self.build_ticket_payload(order_id)
-        self._render_pdf(payload, output_path)
-        self._persist_ticket(order_id, ticket_type, output_path)
-        return output_path
+        created_at = _resolve_datetime(payload)
+        enriched_payload = {
+            **payload,
+            "restaurant_name": "Meserito",
+            "receipt_title": "RECIBO DE COBRO",
+            "mesa": payload.get("table"),
+            "mesero": payload.get("waiter"),
+            "created_at": created_at,
+        }
+        printed_path = print_ticket_document(enriched_payload, output_path)
+        final_path = printed_path or output_path
+        self._persist_ticket(order_id, ticket_type, final_path, payload)
+        return final_path
 
-    def _persist_ticket(self, order_id: int, ticket_type: str, output_path: Path) -> Ticket:
+    def _persist_ticket(
+        self,
+        order_id: int,
+        ticket_type: str,
+        output_path: Path,
+        payload: Dict,
+    ) -> Ticket:
         ticket = self.session.scalar(
             select(Ticket).where(Ticket.order_id == order_id, Ticket.type == ticket_type)
         )
         if ticket:
             ticket.file_path = str(output_path)
             ticket.created_at = datetime.utcnow()
+            ticket.payment_type = payload.get("payment_type")
+            ticket.card_last4 = payload.get("card_last4")
         else:
             ticket = Ticket(
                 order_id=order_id,
                 type=ticket_type,
                 file_path=str(output_path),
+                payment_type=payload.get("payment_type"),
+                card_last4=payload.get("card_last4"),
             )
             self.session.add(ticket)
         self.session.flush()
+        # TODO: Registrar intentos fallidos de impresión.
         return ticket
-
-    def _render_pdf(self, payload: Dict, output_path: Path) -> None:
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        c = canvas.Canvas(str(output_path), pagesize=letter)
-        width, height = letter
-        y = height - 50
-        c.setFont("Helvetica-Bold", 14)
-        c.drawString(50, y, f"Ticket pedido #{payload['order_id']}")
-        y -= 20
-        c.setFont("Helvetica", 11)
-        c.drawString(50, y, f"Mesa: {payload['table']}")
-        y -= 15
-        c.drawString(50, y, f"Mesero: {payload['waiter']}")
-        y -= 15
-        c.drawString(50, y, f"Personas: {payload['covers']}")
-        y -= 20
-        c.drawString(50, y, "Items:")
-        y -= 20
-        for item in payload["items"]:
-            c.drawString(60, y, f"{item['qty']} x {item['name']}")
-            c.drawRightString(width - 60, y, f"${item['total_cents']/100:.2f}")
-            y -= 15
-        y -= 10
-        c.drawRightString(width - 60, y, f"Subtotal: ${payload['subtotal_cents']/100:.2f}")
-        y -= 15
-        c.drawRightString(width - 60, y, f"Impuestos: ${payload['tax_cents']/100:.2f}")
-        y -= 15
-        c.setFont("Helvetica-Bold", 12)
-        c.drawRightString(width - 60, y, f"Total: ${payload['total_cents']/100:.2f}")
-        y -= 30
-        c.setFont("Helvetica", 10)
-        c.drawString(50, y, f"Emitido: {datetime.now():%Y-%m-%d %H:%M}")
-        c.showPage()
-        c.save()

--- a/app/ui/windows/waiter_window.py
+++ b/app/ui/windows/waiter_window.py
@@ -1,23 +1,28 @@
 """Modern POS-style main window for waiters."""
 from __future__ import annotations
 
+from datetime import datetime
 from functools import partial
-from pathlib import Path
 from typing import Dict, List, Optional
 
 from PyQt6.QtCore import Qt, pyqtSignal
 from PyQt6.QtGui import QColor
 from PyQt6.QtWidgets import (
+    QButtonGroup,
     QComboBox,
     QDialog,
+    QDialogButtonBox,
+    QFormLayout,
     QFrame,
     QGridLayout,
     QHBoxLayout,
     QInputDialog,
     QLabel,
+    QLineEdit,
     QMainWindow,
     QMessageBox,
     QPushButton,
+    QRadioButton,
     QScrollArea,
     QSpinBox,
     QVBoxLayout,
@@ -28,6 +33,7 @@ from PyQt6.QtWidgets import (
 from ...event_bus import event_bus
 from ...models import Table, Waiter
 from ...services import MenuService, OrderService, TableService, TicketService
+from ...printing.ticket import ensure_ticket_output_path
 from ..components.product_card import ProductCard
 from ..viewmodels import MenuItemInfo
 
@@ -143,6 +149,87 @@ class QuantityDialog(QDialog):
 
     def _confirm(self) -> None:
         self.quantity = self.spin_box.value()
+        self.accept()
+
+
+class PaymentDialog(QDialog):
+    """Ask the waiter to select the payment method and optional card data."""
+
+    def __init__(self, total_cents: int, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Forma de pago")
+        self.setModal(True)
+
+        self.payment_type: Optional[str] = None
+        self.card_last4: Optional[str] = None
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(24, 24, 24, 24)
+        layout.setSpacing(16)
+
+        heading = QLabel("Selecciona la forma de pago")
+        heading.setProperty("heading", True)
+        heading.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(heading)
+
+        subtitle = QLabel(f"Total a cobrar: ${total_cents / 100:.2f}")
+        subtitle.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(subtitle)
+
+        form = QFormLayout()
+        form.setFormAlignment(Qt.AlignmentFlag.AlignLeft)
+
+        self.button_group = QButtonGroup(self)
+        self.cash_radio = QRadioButton("Efectivo")
+        self.card_radio = QRadioButton("Tarjeta")
+        self.button_group.addButton(self.cash_radio)
+        self.button_group.addButton(self.card_radio)
+        self.cash_radio.setChecked(True)
+
+        form.addRow(self.cash_radio)
+        form.addRow(self.card_radio)
+
+        self.card_last4_input = QLineEdit()
+        self.card_last4_input.setMaxLength(4)
+        self.card_last4_input.setPlaceholderText("Últimos 4 (opcional)")
+        self.card_last4_input.setEnabled(False)
+        form.addRow("Terminación", self.card_last4_input)
+
+        layout.addLayout(form)
+
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Cancel | QDialogButtonBox.StandardButton.Ok
+        )
+        buttons.accepted.connect(self._accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+        self.card_radio.toggled.connect(self._toggle_card_input)
+        # TODO: Permitir agregar propina al flujo de pago.
+
+    def _toggle_card_input(self, checked: bool) -> None:
+        self.card_last4_input.setEnabled(checked)
+        if not checked:
+            self.card_last4_input.clear()
+
+    def _accept(self) -> None:
+        selected_button = self.button_group.checkedButton()
+        if not selected_button:
+            QMessageBox.warning(self, "Meserito", "Selecciona una forma de pago")
+            return
+        self.payment_type = selected_button.text()
+        if self.payment_type == "Tarjeta":
+            value = self.card_last4_input.text().strip()
+            if value and (len(value) != 4 or not value.isdigit()):
+                QMessageBox.warning(
+                    self,
+                    "Meserito",
+                    "Los últimos 4 dígitos deben contener exactamente 4 números",
+                )
+                return
+            self.card_last4 = value or None
+        else:
+            self.card_last4 = None
         self.accept()
 
 
@@ -412,19 +499,41 @@ class WaiterWindow(QMainWindow):
             order_service = OrderService(session)
             table_service = TableService(session)
             order = order_service.compute_totals(self.current_order_id)
+            active_items = [item for item in order.items if item.status != "void"]
+            if not active_items or order.total_cents <= 0:
+                QMessageBox.information(
+                    self,
+                    "Meserito",
+                    "Agrega productos a la orden antes de finalizar",
+                )
+                return
+
+            dialog = PaymentDialog(order.total_cents, self)
+            if not dialog.exec():
+                return
+
+            payment_type = dialog.payment_type or "Efectivo"
+            card_last4 = dialog.card_last4
             closed_order = table_service.close_order(
                 self.selected_table_id,
-                payment_method="efectivo",
+                payment_method=payment_type.lower(),
                 payment_amount_cents=order.total_cents,
+                payment_type=payment_type,
+                card_last4=card_last4,
             )
             ticket_service = TicketService(session)
-            output = Path("tickets") / f"ticket_{order.id}.pdf"
-            ticket_service.generate_pdf(closed_order.id, output, ticket_type="cliente")
+            timestamp = closed_order.closed_at or datetime.utcnow()
+            output = ensure_ticket_output_path(timestamp, closed_order.id)
+            ticket_path = ticket_service.generate_pdf(
+                closed_order.id,
+                output,
+                ticket_type="cliente",
+            )
             session.commit()
             QMessageBox.information(
                 self,
                 "Meserito",
-                f"Cuenta cerrada. Ticket guardado en {output}"
+                f"Cuenta cerrada. Ticket guardado en {ticket_path}"
             )
         except Exception as exc:
             session.rollback()
@@ -441,14 +550,22 @@ class WaiterWindow(QMainWindow):
         try:
             order_service = OrderService(session)
             order = order_service.compute_totals(self.current_order_id)
+            if order.total_cents <= 0:
+                QMessageBox.information(
+                    self,
+                    "Meserito",
+                    "La orden no tiene importe para imprimir",
+                )
+                return
             ticket_service = TicketService(session)
-            output = Path("tickets") / f"ticket_{order.id}.pdf"
-            ticket_service.generate_pdf(order.id, output)
+            timestamp = order.closed_at or datetime.utcnow()
+            output = ensure_ticket_output_path(timestamp, order.id, ensure_closed=False)
+            ticket_path = ticket_service.generate_pdf(order.id, output)
             session.commit()
             QMessageBox.information(
                 self,
                 "Meserito",
-                f"Ticket generado en {output}"
+                f"Ticket generado en {ticket_path}"
             )
         except Exception as exc:
             session.rollback()


### PR DESCRIPTION
## Summary
- enable high-DPI rendering and a unified dark stylesheet across the application
- prompt for payment type when closing orders and persist the selection on orders and tickets
- add an 80mm HTML-based ticket renderer with PDF fallback plus lightweight migrations for new payment metadata

## Testing
- `PYTHONPATH=. pytest` *(fails: missing libGL.so.1 in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dca8d35d0c8325aa5003abf2f92c92